### PR TITLE
refactor to resolve scoping issues

### DIFF
--- a/build/makefile
+++ b/build/makefile
@@ -65,6 +65,16 @@ CMAKE_BINARY_DIR = /workspaces/bird-lang/build
 #=============================================================================
 # Targets provided globally by CMake.
 
+# Special rule for the target rebuild_cache
+rebuild_cache:
+	@$(CMAKE_COMMAND) -E cmake_echo_color --switch=$(COLOR) --cyan "Running CMake to regenerate build system..."
+	/opt/cmake/bin/cmake --regenerate-during-build -S$(CMAKE_SOURCE_DIR) -B$(CMAKE_BINARY_DIR)
+.PHONY : rebuild_cache
+
+# Special rule for the target rebuild_cache
+rebuild_cache/fast: rebuild_cache
+.PHONY : rebuild_cache/fast
+
 # Special rule for the target edit_cache
 edit_cache:
 	@$(CMAKE_COMMAND) -E cmake_echo_color --switch=$(COLOR) --cyan "Running CMake cache editor..."
@@ -75,15 +85,15 @@ edit_cache:
 edit_cache/fast: edit_cache
 .PHONY : edit_cache/fast
 
-# Special rule for the target rebuild_cache
-rebuild_cache:
-	@$(CMAKE_COMMAND) -E cmake_echo_color --switch=$(COLOR) --cyan "Running CMake to regenerate build system..."
-	/opt/cmake/bin/cmake --regenerate-during-build -S$(CMAKE_SOURCE_DIR) -B$(CMAKE_BINARY_DIR)
-.PHONY : rebuild_cache
+# Special rule for the target test
+test:
+	@$(CMAKE_COMMAND) -E cmake_echo_color --switch=$(COLOR) --cyan "Running tests..."
+	/opt/cmake/bin/ctest --force-new-ctest-process $(ARGS)
+.PHONY : test
 
-# Special rule for the target rebuild_cache
-rebuild_cache/fast: rebuild_cache
-.PHONY : rebuild_cache/fast
+# Special rule for the target test
+test/fast: test
+.PHONY : test/fast
 
 # The main all target
 all: cmake_check_build_system
@@ -117,43 +127,147 @@ depend:
 .PHONY : depend
 
 #=============================================================================
-# Target rules for targets named omp_gen
+# Target rules for targets named while_test
 
 # Build rule for target.
-omp_gen: cmake_check_build_system
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 omp_gen
-.PHONY : omp_gen
+while_test: cmake_check_build_system
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 while_test
+.PHONY : while_test
 
 # fast build rule for target.
-omp_gen/fast:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/omp_gen.dir/build.make CMakeFiles/omp_gen.dir/build
-.PHONY : omp_gen/fast
+while_test/fast:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/while_test.dir/build.make CMakeFiles/while_test.dir/build
+.PHONY : while_test/fast
 
 #=============================================================================
-# Target rules for targets named intrinsics_gen
+# Target rules for targets named vars_without_type_test
 
 # Build rule for target.
-intrinsics_gen: cmake_check_build_system
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 intrinsics_gen
-.PHONY : intrinsics_gen
+vars_without_type_test: cmake_check_build_system
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 vars_without_type_test
+.PHONY : vars_without_type_test
 
 # fast build rule for target.
-intrinsics_gen/fast:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/intrinsics_gen.dir/build.make CMakeFiles/intrinsics_gen.dir/build
-.PHONY : intrinsics_gen/fast
+vars_without_type_test/fast:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/vars_without_type_test.dir/build.make CMakeFiles/vars_without_type_test.dir/build
+.PHONY : vars_without_type_test/fast
 
 #=============================================================================
-# Target rules for targets named acc_gen
+# Target rules for targets named vars_with_type_test
 
 # Build rule for target.
-acc_gen: cmake_check_build_system
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 acc_gen
-.PHONY : acc_gen
+vars_with_type_test: cmake_check_build_system
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 vars_with_type_test
+.PHONY : vars_with_type_test
 
 # fast build rule for target.
-acc_gen/fast:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/acc_gen.dir/build.make CMakeFiles/acc_gen.dir/build
-.PHONY : acc_gen/fast
+vars_with_type_test/fast:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/vars_with_type_test.dir/build.make CMakeFiles/vars_with_type_test.dir/build
+.PHONY : vars_with_type_test/fast
+
+#=============================================================================
+# Target rules for targets named var_redeclaration_test
+
+# Build rule for target.
+var_redeclaration_test: cmake_check_build_system
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 var_redeclaration_test
+.PHONY : var_redeclaration_test
+
+# fast build rule for target.
+var_redeclaration_test/fast:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/var_redeclaration_test.dir/build.make CMakeFiles/var_redeclaration_test.dir/build
+.PHONY : var_redeclaration_test/fast
+
+#=============================================================================
+# Target rules for targets named mutability_test
+
+# Build rule for target.
+mutability_test: cmake_check_build_system
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 mutability_test
+.PHONY : mutability_test
+
+# fast build rule for target.
+mutability_test/fast:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/mutability_test.dir/build.make CMakeFiles/mutability_test.dir/build
+.PHONY : mutability_test/fast
+
+#=============================================================================
+# Target rules for targets named ternary_test
+
+# Build rule for target.
+ternary_test: cmake_check_build_system
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 ternary_test
+.PHONY : ternary_test
+
+# fast build rule for target.
+ternary_test/fast:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/ternary_test.dir/build.make CMakeFiles/ternary_test.dir/build
+.PHONY : ternary_test/fast
+
+#=============================================================================
+# Target rules for targets named nested_ternary_test
+
+# Build rule for target.
+nested_ternary_test: cmake_check_build_system
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 nested_ternary_test
+.PHONY : nested_ternary_test
+
+# fast build rule for target.
+nested_ternary_test/fast:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/nested_ternary_test.dir/build.make CMakeFiles/nested_ternary_test.dir/build
+.PHONY : nested_ternary_test/fast
+
+#=============================================================================
+# Target rules for targets named assignment_with_ternary_test
+
+# Build rule for target.
+assignment_with_ternary_test: cmake_check_build_system
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 assignment_with_ternary_test
+.PHONY : assignment_with_ternary_test
+
+# fast build rule for target.
+assignment_with_ternary_test/fast:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/assignment_with_ternary_test.dir/build.make CMakeFiles/assignment_with_ternary_test.dir/build
+.PHONY : assignment_with_ternary_test/fast
+
+#=============================================================================
+# Target rules for targets named vars_scope_test
+
+# Build rule for target.
+vars_scope_test: cmake_check_build_system
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 vars_scope_test
+.PHONY : vars_scope_test
+
+# fast build rule for target.
+vars_scope_test/fast:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/vars_scope_test.dir/build.make CMakeFiles/vars_scope_test.dir/build
+.PHONY : vars_scope_test/fast
+
+#=============================================================================
+# Target rules for targets named var_redeclaration_scope_test
+
+# Build rule for target.
+var_redeclaration_scope_test: cmake_check_build_system
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 var_redeclaration_scope_test
+.PHONY : var_redeclaration_scope_test
+
+# fast build rule for target.
+var_redeclaration_scope_test/fast:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/var_redeclaration_scope_test.dir/build.make CMakeFiles/var_redeclaration_scope_test.dir/build
+.PHONY : var_redeclaration_scope_test/fast
+
+#=============================================================================
+# Target rules for targets named RISCVTargetParserTableGen
+
+# Build rule for target.
+RISCVTargetParserTableGen: cmake_check_build_system
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 RISCVTargetParserTableGen
+.PHONY : RISCVTargetParserTableGen
+
+# fast build rule for target.
+RISCVTargetParserTableGen/fast:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/RISCVTargetParserTableGen.dir/build.make CMakeFiles/RISCVTargetParserTableGen.dir/build
+.PHONY : RISCVTargetParserTableGen/fast
 
 #=============================================================================
 # Target rules for targets named compiler
@@ -169,17 +283,186 @@ compiler/fast:
 .PHONY : compiler/fast
 
 #=============================================================================
-# Target rules for targets named RISCVTargetParserTableGen
+# Target rules for targets named const_with_type_test
 
 # Build rule for target.
-RISCVTargetParserTableGen: cmake_check_build_system
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 RISCVTargetParserTableGen
-.PHONY : RISCVTargetParserTableGen
+const_with_type_test: cmake_check_build_system
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 const_with_type_test
+.PHONY : const_with_type_test
 
 # fast build rule for target.
-RISCVTargetParserTableGen/fast:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/RISCVTargetParserTableGen.dir/build.make CMakeFiles/RISCVTargetParserTableGen.dir/build
-.PHONY : RISCVTargetParserTableGen/fast
+const_with_type_test/fast:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_with_type_test.dir/build.make CMakeFiles/const_with_type_test.dir/build
+.PHONY : const_with_type_test/fast
+
+#=============================================================================
+# Target rules for targets named if_else_test
+
+# Build rule for target.
+if_else_test: cmake_check_build_system
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 if_else_test
+.PHONY : if_else_test
+
+# fast build rule for target.
+if_else_test/fast:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/if_else_test.dir/build.make CMakeFiles/if_else_test.dir/build
+.PHONY : if_else_test/fast
+
+#=============================================================================
+# Target rules for targets named const_redeclaration_test
+
+# Build rule for target.
+const_redeclaration_test: cmake_check_build_system
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 const_redeclaration_test
+.PHONY : const_redeclaration_test
+
+# fast build rule for target.
+const_redeclaration_test/fast:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_redeclaration_test.dir/build.make CMakeFiles/const_redeclaration_test.dir/build
+.PHONY : const_redeclaration_test/fast
+
+#=============================================================================
+# Target rules for targets named acc_gen
+
+# Build rule for target.
+acc_gen: cmake_check_build_system
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 acc_gen
+.PHONY : acc_gen
+
+# fast build rule for target.
+acc_gen/fast:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/acc_gen.dir/build.make CMakeFiles/acc_gen.dir/build
+.PHONY : acc_gen/fast
+
+#=============================================================================
+# Target rules for targets named omp_gen
+
+# Build rule for target.
+omp_gen: cmake_check_build_system
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 omp_gen
+.PHONY : omp_gen
+
+# fast build rule for target.
+omp_gen/fast:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/omp_gen.dir/build.make CMakeFiles/omp_gen.dir/build
+.PHONY : omp_gen/fast
+
+#=============================================================================
+# Target rules for targets named const_without_type_test
+
+# Build rule for target.
+const_without_type_test: cmake_check_build_system
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 const_without_type_test
+.PHONY : const_without_type_test
+
+# fast build rule for target.
+const_without_type_test/fast:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_without_type_test.dir/build.make CMakeFiles/const_without_type_test.dir/build
+.PHONY : const_without_type_test/fast
+
+#=============================================================================
+# Target rules for targets named intrinsics_gen
+
+# Build rule for target.
+intrinsics_gen: cmake_check_build_system
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 intrinsics_gen
+.PHONY : intrinsics_gen
+
+# fast build rule for target.
+intrinsics_gen/fast:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/intrinsics_gen.dir/build.make CMakeFiles/intrinsics_gen.dir/build
+.PHONY : intrinsics_gen/fast
+
+#=============================================================================
+# Target rules for targets named if_test
+
+# Build rule for target.
+if_test: cmake_check_build_system
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 if_test
+.PHONY : if_test
+
+# fast build rule for target.
+if_test/fast:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/if_test.dir/build.make CMakeFiles/if_test.dir/build
+.PHONY : if_test/fast
+
+#=============================================================================
+# Target rules for targets named immutability_test
+
+# Build rule for target.
+immutability_test: cmake_check_build_system
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 immutability_test
+.PHONY : immutability_test
+
+# fast build rule for target.
+immutability_test/fast:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/immutability_test.dir/build.make CMakeFiles/immutability_test.dir/build
+.PHONY : immutability_test/fast
+
+#=============================================================================
+# Target rules for targets named lexer_test
+
+# Build rule for target.
+lexer_test: cmake_check_build_system
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 lexer_test
+.PHONY : lexer_test
+
+# fast build rule for target.
+lexer_test/fast:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/lexer_test.dir/build.make CMakeFiles/lexer_test.dir/build
+.PHONY : lexer_test/fast
+
+#=============================================================================
+# Target rules for targets named parser_test
+
+# Build rule for target.
+parser_test: cmake_check_build_system
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 parser_test
+.PHONY : parser_test
+
+# fast build rule for target.
+parser_test/fast:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/parser_test.dir/build.make CMakeFiles/parser_test.dir/build
+.PHONY : parser_test/fast
+
+#=============================================================================
+# Target rules for targets named if_else_if_else_test
+
+# Build rule for target.
+if_else_if_else_test: cmake_check_build_system
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 if_else_if_else_test
+.PHONY : if_else_if_else_test
+
+# fast build rule for target.
+if_else_if_else_test/fast:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/if_else_if_else_test.dir/build.make CMakeFiles/if_else_if_else_test.dir/build
+.PHONY : if_else_if_else_test/fast
+
+#=============================================================================
+# Target rules for targets named const_redeclaration_scope_test
+
+# Build rule for target.
+const_redeclaration_scope_test: cmake_check_build_system
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 const_redeclaration_scope_test
+.PHONY : const_redeclaration_scope_test
+
+# fast build rule for target.
+const_redeclaration_scope_test/fast:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_redeclaration_scope_test.dir/build.make CMakeFiles/const_redeclaration_scope_test.dir/build
+.PHONY : const_redeclaration_scope_test/fast
+
+#=============================================================================
+# Target rules for targets named const_scope_test
+
+# Build rule for target.
+const_scope_test: cmake_check_build_system
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 const_scope_test
+.PHONY : const_scope_test
+
+# fast build rule for target.
+const_scope_test/fast:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_scope_test.dir/build.make CMakeFiles/const_scope_test.dir/build
+.PHONY : const_scope_test/fast
 
 main.o: main.cpp.o
 .PHONY : main.o
@@ -277,6 +560,510 @@ src/parser.cpp.s:
 	$(MAKE) $(MAKESILENT) -f CMakeFiles/compiler.dir/build.make CMakeFiles/compiler.dir/src/parser.cpp.s
 .PHONY : src/parser.cpp.s
 
+tests/const_test_suite/const_redeclaration_test.o: tests/const_test_suite/const_redeclaration_test.cpp.o
+.PHONY : tests/const_test_suite/const_redeclaration_test.o
+
+# target to build an object file
+tests/const_test_suite/const_redeclaration_test.cpp.o:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_redeclaration_test.dir/build.make CMakeFiles/const_redeclaration_test.dir/tests/const_test_suite/const_redeclaration_test.cpp.o
+.PHONY : tests/const_test_suite/const_redeclaration_test.cpp.o
+
+tests/const_test_suite/const_redeclaration_test.i: tests/const_test_suite/const_redeclaration_test.cpp.i
+.PHONY : tests/const_test_suite/const_redeclaration_test.i
+
+# target to preprocess a source file
+tests/const_test_suite/const_redeclaration_test.cpp.i:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_redeclaration_test.dir/build.make CMakeFiles/const_redeclaration_test.dir/tests/const_test_suite/const_redeclaration_test.cpp.i
+.PHONY : tests/const_test_suite/const_redeclaration_test.cpp.i
+
+tests/const_test_suite/const_redeclaration_test.s: tests/const_test_suite/const_redeclaration_test.cpp.s
+.PHONY : tests/const_test_suite/const_redeclaration_test.s
+
+# target to generate assembly for a file
+tests/const_test_suite/const_redeclaration_test.cpp.s:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_redeclaration_test.dir/build.make CMakeFiles/const_redeclaration_test.dir/tests/const_test_suite/const_redeclaration_test.cpp.s
+.PHONY : tests/const_test_suite/const_redeclaration_test.cpp.s
+
+tests/const_test_suite/const_with_type_test.o: tests/const_test_suite/const_with_type_test.cpp.o
+.PHONY : tests/const_test_suite/const_with_type_test.o
+
+# target to build an object file
+tests/const_test_suite/const_with_type_test.cpp.o:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_with_type_test.dir/build.make CMakeFiles/const_with_type_test.dir/tests/const_test_suite/const_with_type_test.cpp.o
+.PHONY : tests/const_test_suite/const_with_type_test.cpp.o
+
+tests/const_test_suite/const_with_type_test.i: tests/const_test_suite/const_with_type_test.cpp.i
+.PHONY : tests/const_test_suite/const_with_type_test.i
+
+# target to preprocess a source file
+tests/const_test_suite/const_with_type_test.cpp.i:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_with_type_test.dir/build.make CMakeFiles/const_with_type_test.dir/tests/const_test_suite/const_with_type_test.cpp.i
+.PHONY : tests/const_test_suite/const_with_type_test.cpp.i
+
+tests/const_test_suite/const_with_type_test.s: tests/const_test_suite/const_with_type_test.cpp.s
+.PHONY : tests/const_test_suite/const_with_type_test.s
+
+# target to generate assembly for a file
+tests/const_test_suite/const_with_type_test.cpp.s:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_with_type_test.dir/build.make CMakeFiles/const_with_type_test.dir/tests/const_test_suite/const_with_type_test.cpp.s
+.PHONY : tests/const_test_suite/const_with_type_test.cpp.s
+
+tests/const_test_suite/const_without_type_test.o: tests/const_test_suite/const_without_type_test.cpp.o
+.PHONY : tests/const_test_suite/const_without_type_test.o
+
+# target to build an object file
+tests/const_test_suite/const_without_type_test.cpp.o:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_without_type_test.dir/build.make CMakeFiles/const_without_type_test.dir/tests/const_test_suite/const_without_type_test.cpp.o
+.PHONY : tests/const_test_suite/const_without_type_test.cpp.o
+
+tests/const_test_suite/const_without_type_test.i: tests/const_test_suite/const_without_type_test.cpp.i
+.PHONY : tests/const_test_suite/const_without_type_test.i
+
+# target to preprocess a source file
+tests/const_test_suite/const_without_type_test.cpp.i:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_without_type_test.dir/build.make CMakeFiles/const_without_type_test.dir/tests/const_test_suite/const_without_type_test.cpp.i
+.PHONY : tests/const_test_suite/const_without_type_test.cpp.i
+
+tests/const_test_suite/const_without_type_test.s: tests/const_test_suite/const_without_type_test.cpp.s
+.PHONY : tests/const_test_suite/const_without_type_test.s
+
+# target to generate assembly for a file
+tests/const_test_suite/const_without_type_test.cpp.s:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_without_type_test.dir/build.make CMakeFiles/const_without_type_test.dir/tests/const_test_suite/const_without_type_test.cpp.s
+.PHONY : tests/const_test_suite/const_without_type_test.cpp.s
+
+tests/const_test_suite/immutability_test.o: tests/const_test_suite/immutability_test.cpp.o
+.PHONY : tests/const_test_suite/immutability_test.o
+
+# target to build an object file
+tests/const_test_suite/immutability_test.cpp.o:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/immutability_test.dir/build.make CMakeFiles/immutability_test.dir/tests/const_test_suite/immutability_test.cpp.o
+.PHONY : tests/const_test_suite/immutability_test.cpp.o
+
+tests/const_test_suite/immutability_test.i: tests/const_test_suite/immutability_test.cpp.i
+.PHONY : tests/const_test_suite/immutability_test.i
+
+# target to preprocess a source file
+tests/const_test_suite/immutability_test.cpp.i:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/immutability_test.dir/build.make CMakeFiles/immutability_test.dir/tests/const_test_suite/immutability_test.cpp.i
+.PHONY : tests/const_test_suite/immutability_test.cpp.i
+
+tests/const_test_suite/immutability_test.s: tests/const_test_suite/immutability_test.cpp.s
+.PHONY : tests/const_test_suite/immutability_test.s
+
+# target to generate assembly for a file
+tests/const_test_suite/immutability_test.cpp.s:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/immutability_test.dir/build.make CMakeFiles/immutability_test.dir/tests/const_test_suite/immutability_test.cpp.s
+.PHONY : tests/const_test_suite/immutability_test.cpp.s
+
+tests/if_test_suite/if_else_if_else_test.o: tests/if_test_suite/if_else_if_else_test.cpp.o
+.PHONY : tests/if_test_suite/if_else_if_else_test.o
+
+# target to build an object file
+tests/if_test_suite/if_else_if_else_test.cpp.o:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/if_else_if_else_test.dir/build.make CMakeFiles/if_else_if_else_test.dir/tests/if_test_suite/if_else_if_else_test.cpp.o
+.PHONY : tests/if_test_suite/if_else_if_else_test.cpp.o
+
+tests/if_test_suite/if_else_if_else_test.i: tests/if_test_suite/if_else_if_else_test.cpp.i
+.PHONY : tests/if_test_suite/if_else_if_else_test.i
+
+# target to preprocess a source file
+tests/if_test_suite/if_else_if_else_test.cpp.i:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/if_else_if_else_test.dir/build.make CMakeFiles/if_else_if_else_test.dir/tests/if_test_suite/if_else_if_else_test.cpp.i
+.PHONY : tests/if_test_suite/if_else_if_else_test.cpp.i
+
+tests/if_test_suite/if_else_if_else_test.s: tests/if_test_suite/if_else_if_else_test.cpp.s
+.PHONY : tests/if_test_suite/if_else_if_else_test.s
+
+# target to generate assembly for a file
+tests/if_test_suite/if_else_if_else_test.cpp.s:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/if_else_if_else_test.dir/build.make CMakeFiles/if_else_if_else_test.dir/tests/if_test_suite/if_else_if_else_test.cpp.s
+.PHONY : tests/if_test_suite/if_else_if_else_test.cpp.s
+
+tests/if_test_suite/if_else_test.o: tests/if_test_suite/if_else_test.cpp.o
+.PHONY : tests/if_test_suite/if_else_test.o
+
+# target to build an object file
+tests/if_test_suite/if_else_test.cpp.o:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/if_else_test.dir/build.make CMakeFiles/if_else_test.dir/tests/if_test_suite/if_else_test.cpp.o
+.PHONY : tests/if_test_suite/if_else_test.cpp.o
+
+tests/if_test_suite/if_else_test.i: tests/if_test_suite/if_else_test.cpp.i
+.PHONY : tests/if_test_suite/if_else_test.i
+
+# target to preprocess a source file
+tests/if_test_suite/if_else_test.cpp.i:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/if_else_test.dir/build.make CMakeFiles/if_else_test.dir/tests/if_test_suite/if_else_test.cpp.i
+.PHONY : tests/if_test_suite/if_else_test.cpp.i
+
+tests/if_test_suite/if_else_test.s: tests/if_test_suite/if_else_test.cpp.s
+.PHONY : tests/if_test_suite/if_else_test.s
+
+# target to generate assembly for a file
+tests/if_test_suite/if_else_test.cpp.s:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/if_else_test.dir/build.make CMakeFiles/if_else_test.dir/tests/if_test_suite/if_else_test.cpp.s
+.PHONY : tests/if_test_suite/if_else_test.cpp.s
+
+tests/if_test_suite/if_test.o: tests/if_test_suite/if_test.cpp.o
+.PHONY : tests/if_test_suite/if_test.o
+
+# target to build an object file
+tests/if_test_suite/if_test.cpp.o:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/if_test.dir/build.make CMakeFiles/if_test.dir/tests/if_test_suite/if_test.cpp.o
+.PHONY : tests/if_test_suite/if_test.cpp.o
+
+tests/if_test_suite/if_test.i: tests/if_test_suite/if_test.cpp.i
+.PHONY : tests/if_test_suite/if_test.i
+
+# target to preprocess a source file
+tests/if_test_suite/if_test.cpp.i:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/if_test.dir/build.make CMakeFiles/if_test.dir/tests/if_test_suite/if_test.cpp.i
+.PHONY : tests/if_test_suite/if_test.cpp.i
+
+tests/if_test_suite/if_test.s: tests/if_test_suite/if_test.cpp.s
+.PHONY : tests/if_test_suite/if_test.s
+
+# target to generate assembly for a file
+tests/if_test_suite/if_test.cpp.s:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/if_test.dir/build.make CMakeFiles/if_test.dir/tests/if_test_suite/if_test.cpp.s
+.PHONY : tests/if_test_suite/if_test.cpp.s
+
+tests/lexer_test_suite/lexer_test.o: tests/lexer_test_suite/lexer_test.cpp.o
+.PHONY : tests/lexer_test_suite/lexer_test.o
+
+# target to build an object file
+tests/lexer_test_suite/lexer_test.cpp.o:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/lexer_test.dir/build.make CMakeFiles/lexer_test.dir/tests/lexer_test_suite/lexer_test.cpp.o
+.PHONY : tests/lexer_test_suite/lexer_test.cpp.o
+
+tests/lexer_test_suite/lexer_test.i: tests/lexer_test_suite/lexer_test.cpp.i
+.PHONY : tests/lexer_test_suite/lexer_test.i
+
+# target to preprocess a source file
+tests/lexer_test_suite/lexer_test.cpp.i:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/lexer_test.dir/build.make CMakeFiles/lexer_test.dir/tests/lexer_test_suite/lexer_test.cpp.i
+.PHONY : tests/lexer_test_suite/lexer_test.cpp.i
+
+tests/lexer_test_suite/lexer_test.s: tests/lexer_test_suite/lexer_test.cpp.s
+.PHONY : tests/lexer_test_suite/lexer_test.s
+
+# target to generate assembly for a file
+tests/lexer_test_suite/lexer_test.cpp.s:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/lexer_test.dir/build.make CMakeFiles/lexer_test.dir/tests/lexer_test_suite/lexer_test.cpp.s
+.PHONY : tests/lexer_test_suite/lexer_test.cpp.s
+
+tests/parser_test_suite/parser_test.o: tests/parser_test_suite/parser_test.cpp.o
+.PHONY : tests/parser_test_suite/parser_test.o
+
+# target to build an object file
+tests/parser_test_suite/parser_test.cpp.o:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/parser_test.dir/build.make CMakeFiles/parser_test.dir/tests/parser_test_suite/parser_test.cpp.o
+.PHONY : tests/parser_test_suite/parser_test.cpp.o
+
+tests/parser_test_suite/parser_test.i: tests/parser_test_suite/parser_test.cpp.i
+.PHONY : tests/parser_test_suite/parser_test.i
+
+# target to preprocess a source file
+tests/parser_test_suite/parser_test.cpp.i:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/parser_test.dir/build.make CMakeFiles/parser_test.dir/tests/parser_test_suite/parser_test.cpp.i
+.PHONY : tests/parser_test_suite/parser_test.cpp.i
+
+tests/parser_test_suite/parser_test.s: tests/parser_test_suite/parser_test.cpp.s
+.PHONY : tests/parser_test_suite/parser_test.s
+
+# target to generate assembly for a file
+tests/parser_test_suite/parser_test.cpp.s:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/parser_test.dir/build.make CMakeFiles/parser_test.dir/tests/parser_test_suite/parser_test.cpp.s
+.PHONY : tests/parser_test_suite/parser_test.cpp.s
+
+tests/symbol_table_test_suite/const_redeclaration_scope_test.o: tests/symbol_table_test_suite/const_redeclaration_scope_test.cpp.o
+.PHONY : tests/symbol_table_test_suite/const_redeclaration_scope_test.o
+
+# target to build an object file
+tests/symbol_table_test_suite/const_redeclaration_scope_test.cpp.o:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_redeclaration_scope_test.dir/build.make CMakeFiles/const_redeclaration_scope_test.dir/tests/symbol_table_test_suite/const_redeclaration_scope_test.cpp.o
+.PHONY : tests/symbol_table_test_suite/const_redeclaration_scope_test.cpp.o
+
+tests/symbol_table_test_suite/const_redeclaration_scope_test.i: tests/symbol_table_test_suite/const_redeclaration_scope_test.cpp.i
+.PHONY : tests/symbol_table_test_suite/const_redeclaration_scope_test.i
+
+# target to preprocess a source file
+tests/symbol_table_test_suite/const_redeclaration_scope_test.cpp.i:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_redeclaration_scope_test.dir/build.make CMakeFiles/const_redeclaration_scope_test.dir/tests/symbol_table_test_suite/const_redeclaration_scope_test.cpp.i
+.PHONY : tests/symbol_table_test_suite/const_redeclaration_scope_test.cpp.i
+
+tests/symbol_table_test_suite/const_redeclaration_scope_test.s: tests/symbol_table_test_suite/const_redeclaration_scope_test.cpp.s
+.PHONY : tests/symbol_table_test_suite/const_redeclaration_scope_test.s
+
+# target to generate assembly for a file
+tests/symbol_table_test_suite/const_redeclaration_scope_test.cpp.s:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_redeclaration_scope_test.dir/build.make CMakeFiles/const_redeclaration_scope_test.dir/tests/symbol_table_test_suite/const_redeclaration_scope_test.cpp.s
+.PHONY : tests/symbol_table_test_suite/const_redeclaration_scope_test.cpp.s
+
+tests/symbol_table_test_suite/const_scope_test.o: tests/symbol_table_test_suite/const_scope_test.cpp.o
+.PHONY : tests/symbol_table_test_suite/const_scope_test.o
+
+# target to build an object file
+tests/symbol_table_test_suite/const_scope_test.cpp.o:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_scope_test.dir/build.make CMakeFiles/const_scope_test.dir/tests/symbol_table_test_suite/const_scope_test.cpp.o
+.PHONY : tests/symbol_table_test_suite/const_scope_test.cpp.o
+
+tests/symbol_table_test_suite/const_scope_test.i: tests/symbol_table_test_suite/const_scope_test.cpp.i
+.PHONY : tests/symbol_table_test_suite/const_scope_test.i
+
+# target to preprocess a source file
+tests/symbol_table_test_suite/const_scope_test.cpp.i:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_scope_test.dir/build.make CMakeFiles/const_scope_test.dir/tests/symbol_table_test_suite/const_scope_test.cpp.i
+.PHONY : tests/symbol_table_test_suite/const_scope_test.cpp.i
+
+tests/symbol_table_test_suite/const_scope_test.s: tests/symbol_table_test_suite/const_scope_test.cpp.s
+.PHONY : tests/symbol_table_test_suite/const_scope_test.s
+
+# target to generate assembly for a file
+tests/symbol_table_test_suite/const_scope_test.cpp.s:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_scope_test.dir/build.make CMakeFiles/const_scope_test.dir/tests/symbol_table_test_suite/const_scope_test.cpp.s
+.PHONY : tests/symbol_table_test_suite/const_scope_test.cpp.s
+
+tests/symbol_table_test_suite/var_redeclaration_scope_test.o: tests/symbol_table_test_suite/var_redeclaration_scope_test.cpp.o
+.PHONY : tests/symbol_table_test_suite/var_redeclaration_scope_test.o
+
+# target to build an object file
+tests/symbol_table_test_suite/var_redeclaration_scope_test.cpp.o:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/var_redeclaration_scope_test.dir/build.make CMakeFiles/var_redeclaration_scope_test.dir/tests/symbol_table_test_suite/var_redeclaration_scope_test.cpp.o
+.PHONY : tests/symbol_table_test_suite/var_redeclaration_scope_test.cpp.o
+
+tests/symbol_table_test_suite/var_redeclaration_scope_test.i: tests/symbol_table_test_suite/var_redeclaration_scope_test.cpp.i
+.PHONY : tests/symbol_table_test_suite/var_redeclaration_scope_test.i
+
+# target to preprocess a source file
+tests/symbol_table_test_suite/var_redeclaration_scope_test.cpp.i:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/var_redeclaration_scope_test.dir/build.make CMakeFiles/var_redeclaration_scope_test.dir/tests/symbol_table_test_suite/var_redeclaration_scope_test.cpp.i
+.PHONY : tests/symbol_table_test_suite/var_redeclaration_scope_test.cpp.i
+
+tests/symbol_table_test_suite/var_redeclaration_scope_test.s: tests/symbol_table_test_suite/var_redeclaration_scope_test.cpp.s
+.PHONY : tests/symbol_table_test_suite/var_redeclaration_scope_test.s
+
+# target to generate assembly for a file
+tests/symbol_table_test_suite/var_redeclaration_scope_test.cpp.s:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/var_redeclaration_scope_test.dir/build.make CMakeFiles/var_redeclaration_scope_test.dir/tests/symbol_table_test_suite/var_redeclaration_scope_test.cpp.s
+.PHONY : tests/symbol_table_test_suite/var_redeclaration_scope_test.cpp.s
+
+tests/symbol_table_test_suite/vars_scope_test.o: tests/symbol_table_test_suite/vars_scope_test.cpp.o
+.PHONY : tests/symbol_table_test_suite/vars_scope_test.o
+
+# target to build an object file
+tests/symbol_table_test_suite/vars_scope_test.cpp.o:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/vars_scope_test.dir/build.make CMakeFiles/vars_scope_test.dir/tests/symbol_table_test_suite/vars_scope_test.cpp.o
+.PHONY : tests/symbol_table_test_suite/vars_scope_test.cpp.o
+
+tests/symbol_table_test_suite/vars_scope_test.i: tests/symbol_table_test_suite/vars_scope_test.cpp.i
+.PHONY : tests/symbol_table_test_suite/vars_scope_test.i
+
+# target to preprocess a source file
+tests/symbol_table_test_suite/vars_scope_test.cpp.i:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/vars_scope_test.dir/build.make CMakeFiles/vars_scope_test.dir/tests/symbol_table_test_suite/vars_scope_test.cpp.i
+.PHONY : tests/symbol_table_test_suite/vars_scope_test.cpp.i
+
+tests/symbol_table_test_suite/vars_scope_test.s: tests/symbol_table_test_suite/vars_scope_test.cpp.s
+.PHONY : tests/symbol_table_test_suite/vars_scope_test.s
+
+# target to generate assembly for a file
+tests/symbol_table_test_suite/vars_scope_test.cpp.s:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/vars_scope_test.dir/build.make CMakeFiles/vars_scope_test.dir/tests/symbol_table_test_suite/vars_scope_test.cpp.s
+.PHONY : tests/symbol_table_test_suite/vars_scope_test.cpp.s
+
+tests/ternary_test_suite/assignment_with_ternary_test.o: tests/ternary_test_suite/assignment_with_ternary_test.cpp.o
+.PHONY : tests/ternary_test_suite/assignment_with_ternary_test.o
+
+# target to build an object file
+tests/ternary_test_suite/assignment_with_ternary_test.cpp.o:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/assignment_with_ternary_test.dir/build.make CMakeFiles/assignment_with_ternary_test.dir/tests/ternary_test_suite/assignment_with_ternary_test.cpp.o
+.PHONY : tests/ternary_test_suite/assignment_with_ternary_test.cpp.o
+
+tests/ternary_test_suite/assignment_with_ternary_test.i: tests/ternary_test_suite/assignment_with_ternary_test.cpp.i
+.PHONY : tests/ternary_test_suite/assignment_with_ternary_test.i
+
+# target to preprocess a source file
+tests/ternary_test_suite/assignment_with_ternary_test.cpp.i:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/assignment_with_ternary_test.dir/build.make CMakeFiles/assignment_with_ternary_test.dir/tests/ternary_test_suite/assignment_with_ternary_test.cpp.i
+.PHONY : tests/ternary_test_suite/assignment_with_ternary_test.cpp.i
+
+tests/ternary_test_suite/assignment_with_ternary_test.s: tests/ternary_test_suite/assignment_with_ternary_test.cpp.s
+.PHONY : tests/ternary_test_suite/assignment_with_ternary_test.s
+
+# target to generate assembly for a file
+tests/ternary_test_suite/assignment_with_ternary_test.cpp.s:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/assignment_with_ternary_test.dir/build.make CMakeFiles/assignment_with_ternary_test.dir/tests/ternary_test_suite/assignment_with_ternary_test.cpp.s
+.PHONY : tests/ternary_test_suite/assignment_with_ternary_test.cpp.s
+
+tests/ternary_test_suite/nested_ternary_test.o: tests/ternary_test_suite/nested_ternary_test.cpp.o
+.PHONY : tests/ternary_test_suite/nested_ternary_test.o
+
+# target to build an object file
+tests/ternary_test_suite/nested_ternary_test.cpp.o:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/nested_ternary_test.dir/build.make CMakeFiles/nested_ternary_test.dir/tests/ternary_test_suite/nested_ternary_test.cpp.o
+.PHONY : tests/ternary_test_suite/nested_ternary_test.cpp.o
+
+tests/ternary_test_suite/nested_ternary_test.i: tests/ternary_test_suite/nested_ternary_test.cpp.i
+.PHONY : tests/ternary_test_suite/nested_ternary_test.i
+
+# target to preprocess a source file
+tests/ternary_test_suite/nested_ternary_test.cpp.i:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/nested_ternary_test.dir/build.make CMakeFiles/nested_ternary_test.dir/tests/ternary_test_suite/nested_ternary_test.cpp.i
+.PHONY : tests/ternary_test_suite/nested_ternary_test.cpp.i
+
+tests/ternary_test_suite/nested_ternary_test.s: tests/ternary_test_suite/nested_ternary_test.cpp.s
+.PHONY : tests/ternary_test_suite/nested_ternary_test.s
+
+# target to generate assembly for a file
+tests/ternary_test_suite/nested_ternary_test.cpp.s:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/nested_ternary_test.dir/build.make CMakeFiles/nested_ternary_test.dir/tests/ternary_test_suite/nested_ternary_test.cpp.s
+.PHONY : tests/ternary_test_suite/nested_ternary_test.cpp.s
+
+tests/ternary_test_suite/ternary_test.o: tests/ternary_test_suite/ternary_test.cpp.o
+.PHONY : tests/ternary_test_suite/ternary_test.o
+
+# target to build an object file
+tests/ternary_test_suite/ternary_test.cpp.o:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/ternary_test.dir/build.make CMakeFiles/ternary_test.dir/tests/ternary_test_suite/ternary_test.cpp.o
+.PHONY : tests/ternary_test_suite/ternary_test.cpp.o
+
+tests/ternary_test_suite/ternary_test.i: tests/ternary_test_suite/ternary_test.cpp.i
+.PHONY : tests/ternary_test_suite/ternary_test.i
+
+# target to preprocess a source file
+tests/ternary_test_suite/ternary_test.cpp.i:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/ternary_test.dir/build.make CMakeFiles/ternary_test.dir/tests/ternary_test_suite/ternary_test.cpp.i
+.PHONY : tests/ternary_test_suite/ternary_test.cpp.i
+
+tests/ternary_test_suite/ternary_test.s: tests/ternary_test_suite/ternary_test.cpp.s
+.PHONY : tests/ternary_test_suite/ternary_test.s
+
+# target to generate assembly for a file
+tests/ternary_test_suite/ternary_test.cpp.s:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/ternary_test.dir/build.make CMakeFiles/ternary_test.dir/tests/ternary_test_suite/ternary_test.cpp.s
+.PHONY : tests/ternary_test_suite/ternary_test.cpp.s
+
+tests/vars_test_suite/mutability_test.o: tests/vars_test_suite/mutability_test.cpp.o
+.PHONY : tests/vars_test_suite/mutability_test.o
+
+# target to build an object file
+tests/vars_test_suite/mutability_test.cpp.o:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/mutability_test.dir/build.make CMakeFiles/mutability_test.dir/tests/vars_test_suite/mutability_test.cpp.o
+.PHONY : tests/vars_test_suite/mutability_test.cpp.o
+
+tests/vars_test_suite/mutability_test.i: tests/vars_test_suite/mutability_test.cpp.i
+.PHONY : tests/vars_test_suite/mutability_test.i
+
+# target to preprocess a source file
+tests/vars_test_suite/mutability_test.cpp.i:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/mutability_test.dir/build.make CMakeFiles/mutability_test.dir/tests/vars_test_suite/mutability_test.cpp.i
+.PHONY : tests/vars_test_suite/mutability_test.cpp.i
+
+tests/vars_test_suite/mutability_test.s: tests/vars_test_suite/mutability_test.cpp.s
+.PHONY : tests/vars_test_suite/mutability_test.s
+
+# target to generate assembly for a file
+tests/vars_test_suite/mutability_test.cpp.s:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/mutability_test.dir/build.make CMakeFiles/mutability_test.dir/tests/vars_test_suite/mutability_test.cpp.s
+.PHONY : tests/vars_test_suite/mutability_test.cpp.s
+
+tests/vars_test_suite/var_redeclaration_test.o: tests/vars_test_suite/var_redeclaration_test.cpp.o
+.PHONY : tests/vars_test_suite/var_redeclaration_test.o
+
+# target to build an object file
+tests/vars_test_suite/var_redeclaration_test.cpp.o:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/var_redeclaration_test.dir/build.make CMakeFiles/var_redeclaration_test.dir/tests/vars_test_suite/var_redeclaration_test.cpp.o
+.PHONY : tests/vars_test_suite/var_redeclaration_test.cpp.o
+
+tests/vars_test_suite/var_redeclaration_test.i: tests/vars_test_suite/var_redeclaration_test.cpp.i
+.PHONY : tests/vars_test_suite/var_redeclaration_test.i
+
+# target to preprocess a source file
+tests/vars_test_suite/var_redeclaration_test.cpp.i:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/var_redeclaration_test.dir/build.make CMakeFiles/var_redeclaration_test.dir/tests/vars_test_suite/var_redeclaration_test.cpp.i
+.PHONY : tests/vars_test_suite/var_redeclaration_test.cpp.i
+
+tests/vars_test_suite/var_redeclaration_test.s: tests/vars_test_suite/var_redeclaration_test.cpp.s
+.PHONY : tests/vars_test_suite/var_redeclaration_test.s
+
+# target to generate assembly for a file
+tests/vars_test_suite/var_redeclaration_test.cpp.s:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/var_redeclaration_test.dir/build.make CMakeFiles/var_redeclaration_test.dir/tests/vars_test_suite/var_redeclaration_test.cpp.s
+.PHONY : tests/vars_test_suite/var_redeclaration_test.cpp.s
+
+tests/vars_test_suite/vars_with_type_test.o: tests/vars_test_suite/vars_with_type_test.cpp.o
+.PHONY : tests/vars_test_suite/vars_with_type_test.o
+
+# target to build an object file
+tests/vars_test_suite/vars_with_type_test.cpp.o:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/vars_with_type_test.dir/build.make CMakeFiles/vars_with_type_test.dir/tests/vars_test_suite/vars_with_type_test.cpp.o
+.PHONY : tests/vars_test_suite/vars_with_type_test.cpp.o
+
+tests/vars_test_suite/vars_with_type_test.i: tests/vars_test_suite/vars_with_type_test.cpp.i
+.PHONY : tests/vars_test_suite/vars_with_type_test.i
+
+# target to preprocess a source file
+tests/vars_test_suite/vars_with_type_test.cpp.i:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/vars_with_type_test.dir/build.make CMakeFiles/vars_with_type_test.dir/tests/vars_test_suite/vars_with_type_test.cpp.i
+.PHONY : tests/vars_test_suite/vars_with_type_test.cpp.i
+
+tests/vars_test_suite/vars_with_type_test.s: tests/vars_test_suite/vars_with_type_test.cpp.s
+.PHONY : tests/vars_test_suite/vars_with_type_test.s
+
+# target to generate assembly for a file
+tests/vars_test_suite/vars_with_type_test.cpp.s:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/vars_with_type_test.dir/build.make CMakeFiles/vars_with_type_test.dir/tests/vars_test_suite/vars_with_type_test.cpp.s
+.PHONY : tests/vars_test_suite/vars_with_type_test.cpp.s
+
+tests/vars_test_suite/vars_without_type_test.o: tests/vars_test_suite/vars_without_type_test.cpp.o
+.PHONY : tests/vars_test_suite/vars_without_type_test.o
+
+# target to build an object file
+tests/vars_test_suite/vars_without_type_test.cpp.o:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/vars_without_type_test.dir/build.make CMakeFiles/vars_without_type_test.dir/tests/vars_test_suite/vars_without_type_test.cpp.o
+.PHONY : tests/vars_test_suite/vars_without_type_test.cpp.o
+
+tests/vars_test_suite/vars_without_type_test.i: tests/vars_test_suite/vars_without_type_test.cpp.i
+.PHONY : tests/vars_test_suite/vars_without_type_test.i
+
+# target to preprocess a source file
+tests/vars_test_suite/vars_without_type_test.cpp.i:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/vars_without_type_test.dir/build.make CMakeFiles/vars_without_type_test.dir/tests/vars_test_suite/vars_without_type_test.cpp.i
+.PHONY : tests/vars_test_suite/vars_without_type_test.cpp.i
+
+tests/vars_test_suite/vars_without_type_test.s: tests/vars_test_suite/vars_without_type_test.cpp.s
+.PHONY : tests/vars_test_suite/vars_without_type_test.s
+
+# target to generate assembly for a file
+tests/vars_test_suite/vars_without_type_test.cpp.s:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/vars_without_type_test.dir/build.make CMakeFiles/vars_without_type_test.dir/tests/vars_test_suite/vars_without_type_test.cpp.s
+.PHONY : tests/vars_test_suite/vars_without_type_test.cpp.s
+
+tests/while_test_suite/while_test.o: tests/while_test_suite/while_test.cpp.o
+.PHONY : tests/while_test_suite/while_test.o
+
+# target to build an object file
+tests/while_test_suite/while_test.cpp.o:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/while_test.dir/build.make CMakeFiles/while_test.dir/tests/while_test_suite/while_test.cpp.o
+.PHONY : tests/while_test_suite/while_test.cpp.o
+
+tests/while_test_suite/while_test.i: tests/while_test_suite/while_test.cpp.i
+.PHONY : tests/while_test_suite/while_test.i
+
+# target to preprocess a source file
+tests/while_test_suite/while_test.cpp.i:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/while_test.dir/build.make CMakeFiles/while_test.dir/tests/while_test_suite/while_test.cpp.i
+.PHONY : tests/while_test_suite/while_test.cpp.i
+
+tests/while_test_suite/while_test.s: tests/while_test_suite/while_test.cpp.s
+.PHONY : tests/while_test_suite/while_test.s
+
+# target to generate assembly for a file
+tests/while_test_suite/while_test.cpp.s:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/while_test.dir/build.make CMakeFiles/while_test.dir/tests/while_test_suite/while_test.cpp.s
+.PHONY : tests/while_test_suite/while_test.cpp.s
+
 # Help Target
 help:
 	@echo "The following are some of the valid targets for this Makefile:"
@@ -285,11 +1072,33 @@ help:
 	@echo "... depend"
 	@echo "... edit_cache"
 	@echo "... rebuild_cache"
+	@echo "... test"
 	@echo "... RISCVTargetParserTableGen"
 	@echo "... acc_gen"
 	@echo "... intrinsics_gen"
 	@echo "... omp_gen"
+	@echo "... assignment_with_ternary_test"
 	@echo "... compiler"
+	@echo "... const_redeclaration_scope_test"
+	@echo "... const_redeclaration_test"
+	@echo "... const_scope_test"
+	@echo "... const_with_type_test"
+	@echo "... const_without_type_test"
+	@echo "... if_else_if_else_test"
+	@echo "... if_else_test"
+	@echo "... if_test"
+	@echo "... immutability_test"
+	@echo "... lexer_test"
+	@echo "... mutability_test"
+	@echo "... nested_ternary_test"
+	@echo "... parser_test"
+	@echo "... ternary_test"
+	@echo "... var_redeclaration_scope_test"
+	@echo "... var_redeclaration_test"
+	@echo "... vars_scope_test"
+	@echo "... vars_with_type_test"
+	@echo "... vars_without_type_test"
+	@echo "... while_test"
 	@echo "... main.o"
 	@echo "... main.i"
 	@echo "... main.s"
@@ -302,6 +1111,69 @@ help:
 	@echo "... src/parser.o"
 	@echo "... src/parser.i"
 	@echo "... src/parser.s"
+	@echo "... tests/const_test_suite/const_redeclaration_test.o"
+	@echo "... tests/const_test_suite/const_redeclaration_test.i"
+	@echo "... tests/const_test_suite/const_redeclaration_test.s"
+	@echo "... tests/const_test_suite/const_with_type_test.o"
+	@echo "... tests/const_test_suite/const_with_type_test.i"
+	@echo "... tests/const_test_suite/const_with_type_test.s"
+	@echo "... tests/const_test_suite/const_without_type_test.o"
+	@echo "... tests/const_test_suite/const_without_type_test.i"
+	@echo "... tests/const_test_suite/const_without_type_test.s"
+	@echo "... tests/const_test_suite/immutability_test.o"
+	@echo "... tests/const_test_suite/immutability_test.i"
+	@echo "... tests/const_test_suite/immutability_test.s"
+	@echo "... tests/if_test_suite/if_else_if_else_test.o"
+	@echo "... tests/if_test_suite/if_else_if_else_test.i"
+	@echo "... tests/if_test_suite/if_else_if_else_test.s"
+	@echo "... tests/if_test_suite/if_else_test.o"
+	@echo "... tests/if_test_suite/if_else_test.i"
+	@echo "... tests/if_test_suite/if_else_test.s"
+	@echo "... tests/if_test_suite/if_test.o"
+	@echo "... tests/if_test_suite/if_test.i"
+	@echo "... tests/if_test_suite/if_test.s"
+	@echo "... tests/lexer_test_suite/lexer_test.o"
+	@echo "... tests/lexer_test_suite/lexer_test.i"
+	@echo "... tests/lexer_test_suite/lexer_test.s"
+	@echo "... tests/parser_test_suite/parser_test.o"
+	@echo "... tests/parser_test_suite/parser_test.i"
+	@echo "... tests/parser_test_suite/parser_test.s"
+	@echo "... tests/symbol_table_test_suite/const_redeclaration_scope_test.o"
+	@echo "... tests/symbol_table_test_suite/const_redeclaration_scope_test.i"
+	@echo "... tests/symbol_table_test_suite/const_redeclaration_scope_test.s"
+	@echo "... tests/symbol_table_test_suite/const_scope_test.o"
+	@echo "... tests/symbol_table_test_suite/const_scope_test.i"
+	@echo "... tests/symbol_table_test_suite/const_scope_test.s"
+	@echo "... tests/symbol_table_test_suite/var_redeclaration_scope_test.o"
+	@echo "... tests/symbol_table_test_suite/var_redeclaration_scope_test.i"
+	@echo "... tests/symbol_table_test_suite/var_redeclaration_scope_test.s"
+	@echo "... tests/symbol_table_test_suite/vars_scope_test.o"
+	@echo "... tests/symbol_table_test_suite/vars_scope_test.i"
+	@echo "... tests/symbol_table_test_suite/vars_scope_test.s"
+	@echo "... tests/ternary_test_suite/assignment_with_ternary_test.o"
+	@echo "... tests/ternary_test_suite/assignment_with_ternary_test.i"
+	@echo "... tests/ternary_test_suite/assignment_with_ternary_test.s"
+	@echo "... tests/ternary_test_suite/nested_ternary_test.o"
+	@echo "... tests/ternary_test_suite/nested_ternary_test.i"
+	@echo "... tests/ternary_test_suite/nested_ternary_test.s"
+	@echo "... tests/ternary_test_suite/ternary_test.o"
+	@echo "... tests/ternary_test_suite/ternary_test.i"
+	@echo "... tests/ternary_test_suite/ternary_test.s"
+	@echo "... tests/vars_test_suite/mutability_test.o"
+	@echo "... tests/vars_test_suite/mutability_test.i"
+	@echo "... tests/vars_test_suite/mutability_test.s"
+	@echo "... tests/vars_test_suite/var_redeclaration_test.o"
+	@echo "... tests/vars_test_suite/var_redeclaration_test.i"
+	@echo "... tests/vars_test_suite/var_redeclaration_test.s"
+	@echo "... tests/vars_test_suite/vars_with_type_test.o"
+	@echo "... tests/vars_test_suite/vars_with_type_test.i"
+	@echo "... tests/vars_test_suite/vars_with_type_test.s"
+	@echo "... tests/vars_test_suite/vars_without_type_test.o"
+	@echo "... tests/vars_test_suite/vars_without_type_test.i"
+	@echo "... tests/vars_test_suite/vars_without_type_test.s"
+	@echo "... tests/while_test_suite/while_test.o"
+	@echo "... tests/while_test_suite/while_test.i"
+	@echo "... tests/while_test_suite/while_test.s"
 .PHONY : help
 
 

--- a/build/makefile
+++ b/build/makefile
@@ -65,16 +65,6 @@ CMAKE_BINARY_DIR = /workspaces/bird-lang/build
 #=============================================================================
 # Targets provided globally by CMake.
 
-# Special rule for the target rebuild_cache
-rebuild_cache:
-	@$(CMAKE_COMMAND) -E cmake_echo_color --switch=$(COLOR) --cyan "Running CMake to regenerate build system..."
-	/opt/cmake/bin/cmake --regenerate-during-build -S$(CMAKE_SOURCE_DIR) -B$(CMAKE_BINARY_DIR)
-.PHONY : rebuild_cache
-
-# Special rule for the target rebuild_cache
-rebuild_cache/fast: rebuild_cache
-.PHONY : rebuild_cache/fast
-
 # Special rule for the target edit_cache
 edit_cache:
 	@$(CMAKE_COMMAND) -E cmake_echo_color --switch=$(COLOR) --cyan "Running CMake cache editor..."
@@ -85,15 +75,15 @@ edit_cache:
 edit_cache/fast: edit_cache
 .PHONY : edit_cache/fast
 
-# Special rule for the target test
-test:
-	@$(CMAKE_COMMAND) -E cmake_echo_color --switch=$(COLOR) --cyan "Running tests..."
-	/opt/cmake/bin/ctest --force-new-ctest-process $(ARGS)
-.PHONY : test
+# Special rule for the target rebuild_cache
+rebuild_cache:
+	@$(CMAKE_COMMAND) -E cmake_echo_color --switch=$(COLOR) --cyan "Running CMake to regenerate build system..."
+	/opt/cmake/bin/cmake --regenerate-during-build -S$(CMAKE_SOURCE_DIR) -B$(CMAKE_BINARY_DIR)
+.PHONY : rebuild_cache
 
-# Special rule for the target test
-test/fast: test
-.PHONY : test/fast
+# Special rule for the target rebuild_cache
+rebuild_cache/fast: rebuild_cache
+.PHONY : rebuild_cache/fast
 
 # The main all target
 all: cmake_check_build_system
@@ -127,214 +117,6 @@ depend:
 .PHONY : depend
 
 #=============================================================================
-# Target rules for targets named while_test
-
-# Build rule for target.
-while_test: cmake_check_build_system
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 while_test
-.PHONY : while_test
-
-# fast build rule for target.
-while_test/fast:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/while_test.dir/build.make CMakeFiles/while_test.dir/build
-.PHONY : while_test/fast
-
-#=============================================================================
-# Target rules for targets named vars_without_type_test
-
-# Build rule for target.
-vars_without_type_test: cmake_check_build_system
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 vars_without_type_test
-.PHONY : vars_without_type_test
-
-# fast build rule for target.
-vars_without_type_test/fast:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/vars_without_type_test.dir/build.make CMakeFiles/vars_without_type_test.dir/build
-.PHONY : vars_without_type_test/fast
-
-#=============================================================================
-# Target rules for targets named vars_with_type_test
-
-# Build rule for target.
-vars_with_type_test: cmake_check_build_system
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 vars_with_type_test
-.PHONY : vars_with_type_test
-
-# fast build rule for target.
-vars_with_type_test/fast:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/vars_with_type_test.dir/build.make CMakeFiles/vars_with_type_test.dir/build
-.PHONY : vars_with_type_test/fast
-
-#=============================================================================
-# Target rules for targets named var_redeclaration_test
-
-# Build rule for target.
-var_redeclaration_test: cmake_check_build_system
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 var_redeclaration_test
-.PHONY : var_redeclaration_test
-
-# fast build rule for target.
-var_redeclaration_test/fast:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/var_redeclaration_test.dir/build.make CMakeFiles/var_redeclaration_test.dir/build
-.PHONY : var_redeclaration_test/fast
-
-#=============================================================================
-# Target rules for targets named mutability_test
-
-# Build rule for target.
-mutability_test: cmake_check_build_system
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 mutability_test
-.PHONY : mutability_test
-
-# fast build rule for target.
-mutability_test/fast:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/mutability_test.dir/build.make CMakeFiles/mutability_test.dir/build
-.PHONY : mutability_test/fast
-
-#=============================================================================
-# Target rules for targets named ternary_test
-
-# Build rule for target.
-ternary_test: cmake_check_build_system
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 ternary_test
-.PHONY : ternary_test
-
-# fast build rule for target.
-ternary_test/fast:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/ternary_test.dir/build.make CMakeFiles/ternary_test.dir/build
-.PHONY : ternary_test/fast
-
-#=============================================================================
-# Target rules for targets named nested_ternary_test
-
-# Build rule for target.
-nested_ternary_test: cmake_check_build_system
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 nested_ternary_test
-.PHONY : nested_ternary_test
-
-# fast build rule for target.
-nested_ternary_test/fast:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/nested_ternary_test.dir/build.make CMakeFiles/nested_ternary_test.dir/build
-.PHONY : nested_ternary_test/fast
-
-#=============================================================================
-# Target rules for targets named assignment_with_ternary_test
-
-# Build rule for target.
-assignment_with_ternary_test: cmake_check_build_system
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 assignment_with_ternary_test
-.PHONY : assignment_with_ternary_test
-
-# fast build rule for target.
-assignment_with_ternary_test/fast:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/assignment_with_ternary_test.dir/build.make CMakeFiles/assignment_with_ternary_test.dir/build
-.PHONY : assignment_with_ternary_test/fast
-
-#=============================================================================
-# Target rules for targets named vars_scope_test
-
-# Build rule for target.
-vars_scope_test: cmake_check_build_system
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 vars_scope_test
-.PHONY : vars_scope_test
-
-# fast build rule for target.
-vars_scope_test/fast:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/vars_scope_test.dir/build.make CMakeFiles/vars_scope_test.dir/build
-.PHONY : vars_scope_test/fast
-
-#=============================================================================
-# Target rules for targets named var_redeclaration_scope_test
-
-# Build rule for target.
-var_redeclaration_scope_test: cmake_check_build_system
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 var_redeclaration_scope_test
-.PHONY : var_redeclaration_scope_test
-
-# fast build rule for target.
-var_redeclaration_scope_test/fast:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/var_redeclaration_scope_test.dir/build.make CMakeFiles/var_redeclaration_scope_test.dir/build
-.PHONY : var_redeclaration_scope_test/fast
-
-#=============================================================================
-# Target rules for targets named RISCVTargetParserTableGen
-
-# Build rule for target.
-RISCVTargetParserTableGen: cmake_check_build_system
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 RISCVTargetParserTableGen
-.PHONY : RISCVTargetParserTableGen
-
-# fast build rule for target.
-RISCVTargetParserTableGen/fast:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/RISCVTargetParserTableGen.dir/build.make CMakeFiles/RISCVTargetParserTableGen.dir/build
-.PHONY : RISCVTargetParserTableGen/fast
-
-#=============================================================================
-# Target rules for targets named compiler
-
-# Build rule for target.
-compiler: cmake_check_build_system
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 compiler
-.PHONY : compiler
-
-# fast build rule for target.
-compiler/fast:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/compiler.dir/build.make CMakeFiles/compiler.dir/build
-.PHONY : compiler/fast
-
-#=============================================================================
-# Target rules for targets named const_with_type_test
-
-# Build rule for target.
-const_with_type_test: cmake_check_build_system
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 const_with_type_test
-.PHONY : const_with_type_test
-
-# fast build rule for target.
-const_with_type_test/fast:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_with_type_test.dir/build.make CMakeFiles/const_with_type_test.dir/build
-.PHONY : const_with_type_test/fast
-
-#=============================================================================
-# Target rules for targets named if_else_test
-
-# Build rule for target.
-if_else_test: cmake_check_build_system
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 if_else_test
-.PHONY : if_else_test
-
-# fast build rule for target.
-if_else_test/fast:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/if_else_test.dir/build.make CMakeFiles/if_else_test.dir/build
-.PHONY : if_else_test/fast
-
-#=============================================================================
-# Target rules for targets named const_redeclaration_test
-
-# Build rule for target.
-const_redeclaration_test: cmake_check_build_system
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 const_redeclaration_test
-.PHONY : const_redeclaration_test
-
-# fast build rule for target.
-const_redeclaration_test/fast:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_redeclaration_test.dir/build.make CMakeFiles/const_redeclaration_test.dir/build
-.PHONY : const_redeclaration_test/fast
-
-#=============================================================================
-# Target rules for targets named acc_gen
-
-# Build rule for target.
-acc_gen: cmake_check_build_system
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 acc_gen
-.PHONY : acc_gen
-
-# fast build rule for target.
-acc_gen/fast:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/acc_gen.dir/build.make CMakeFiles/acc_gen.dir/build
-.PHONY : acc_gen/fast
-
-#=============================================================================
 # Target rules for targets named omp_gen
 
 # Build rule for target.
@@ -346,19 +128,6 @@ omp_gen: cmake_check_build_system
 omp_gen/fast:
 	$(MAKE) $(MAKESILENT) -f CMakeFiles/omp_gen.dir/build.make CMakeFiles/omp_gen.dir/build
 .PHONY : omp_gen/fast
-
-#=============================================================================
-# Target rules for targets named const_without_type_test
-
-# Build rule for target.
-const_without_type_test: cmake_check_build_system
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 const_without_type_test
-.PHONY : const_without_type_test
-
-# fast build rule for target.
-const_without_type_test/fast:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_without_type_test.dir/build.make CMakeFiles/const_without_type_test.dir/build
-.PHONY : const_without_type_test/fast
 
 #=============================================================================
 # Target rules for targets named intrinsics_gen
@@ -374,95 +143,43 @@ intrinsics_gen/fast:
 .PHONY : intrinsics_gen/fast
 
 #=============================================================================
-# Target rules for targets named if_test
+# Target rules for targets named acc_gen
 
 # Build rule for target.
-if_test: cmake_check_build_system
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 if_test
-.PHONY : if_test
+acc_gen: cmake_check_build_system
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 acc_gen
+.PHONY : acc_gen
 
 # fast build rule for target.
-if_test/fast:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/if_test.dir/build.make CMakeFiles/if_test.dir/build
-.PHONY : if_test/fast
+acc_gen/fast:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/acc_gen.dir/build.make CMakeFiles/acc_gen.dir/build
+.PHONY : acc_gen/fast
 
 #=============================================================================
-# Target rules for targets named immutability_test
+# Target rules for targets named compiler
 
 # Build rule for target.
-immutability_test: cmake_check_build_system
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 immutability_test
-.PHONY : immutability_test
+compiler: cmake_check_build_system
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 compiler
+.PHONY : compiler
 
 # fast build rule for target.
-immutability_test/fast:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/immutability_test.dir/build.make CMakeFiles/immutability_test.dir/build
-.PHONY : immutability_test/fast
+compiler/fast:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/compiler.dir/build.make CMakeFiles/compiler.dir/build
+.PHONY : compiler/fast
 
 #=============================================================================
-# Target rules for targets named lexer_test
+# Target rules for targets named RISCVTargetParserTableGen
 
 # Build rule for target.
-lexer_test: cmake_check_build_system
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 lexer_test
-.PHONY : lexer_test
+RISCVTargetParserTableGen: cmake_check_build_system
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 RISCVTargetParserTableGen
+.PHONY : RISCVTargetParserTableGen
 
 # fast build rule for target.
-lexer_test/fast:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/lexer_test.dir/build.make CMakeFiles/lexer_test.dir/build
-.PHONY : lexer_test/fast
-
-#=============================================================================
-# Target rules for targets named parser_test
-
-# Build rule for target.
-parser_test: cmake_check_build_system
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 parser_test
-.PHONY : parser_test
-
-# fast build rule for target.
-parser_test/fast:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/parser_test.dir/build.make CMakeFiles/parser_test.dir/build
-.PHONY : parser_test/fast
-
-#=============================================================================
-# Target rules for targets named if_else_if_else_test
-
-# Build rule for target.
-if_else_if_else_test: cmake_check_build_system
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 if_else_if_else_test
-.PHONY : if_else_if_else_test
-
-# fast build rule for target.
-if_else_if_else_test/fast:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/if_else_if_else_test.dir/build.make CMakeFiles/if_else_if_else_test.dir/build
-.PHONY : if_else_if_else_test/fast
-
-#=============================================================================
-# Target rules for targets named const_redeclaration_scope_test
-
-# Build rule for target.
-const_redeclaration_scope_test: cmake_check_build_system
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 const_redeclaration_scope_test
-.PHONY : const_redeclaration_scope_test
-
-# fast build rule for target.
-const_redeclaration_scope_test/fast:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_redeclaration_scope_test.dir/build.make CMakeFiles/const_redeclaration_scope_test.dir/build
-.PHONY : const_redeclaration_scope_test/fast
-
-#=============================================================================
-# Target rules for targets named const_scope_test
-
-# Build rule for target.
-const_scope_test: cmake_check_build_system
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 const_scope_test
-.PHONY : const_scope_test
-
-# fast build rule for target.
-const_scope_test/fast:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_scope_test.dir/build.make CMakeFiles/const_scope_test.dir/build
-.PHONY : const_scope_test/fast
+RISCVTargetParserTableGen/fast:
+	$(MAKE) $(MAKESILENT) -f CMakeFiles/RISCVTargetParserTableGen.dir/build.make CMakeFiles/RISCVTargetParserTableGen.dir/build
+.PHONY : RISCVTargetParserTableGen/fast
 
 main.o: main.cpp.o
 .PHONY : main.o
@@ -560,510 +277,6 @@ src/parser.cpp.s:
 	$(MAKE) $(MAKESILENT) -f CMakeFiles/compiler.dir/build.make CMakeFiles/compiler.dir/src/parser.cpp.s
 .PHONY : src/parser.cpp.s
 
-tests/const_test_suite/const_redeclaration_test.o: tests/const_test_suite/const_redeclaration_test.cpp.o
-.PHONY : tests/const_test_suite/const_redeclaration_test.o
-
-# target to build an object file
-tests/const_test_suite/const_redeclaration_test.cpp.o:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_redeclaration_test.dir/build.make CMakeFiles/const_redeclaration_test.dir/tests/const_test_suite/const_redeclaration_test.cpp.o
-.PHONY : tests/const_test_suite/const_redeclaration_test.cpp.o
-
-tests/const_test_suite/const_redeclaration_test.i: tests/const_test_suite/const_redeclaration_test.cpp.i
-.PHONY : tests/const_test_suite/const_redeclaration_test.i
-
-# target to preprocess a source file
-tests/const_test_suite/const_redeclaration_test.cpp.i:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_redeclaration_test.dir/build.make CMakeFiles/const_redeclaration_test.dir/tests/const_test_suite/const_redeclaration_test.cpp.i
-.PHONY : tests/const_test_suite/const_redeclaration_test.cpp.i
-
-tests/const_test_suite/const_redeclaration_test.s: tests/const_test_suite/const_redeclaration_test.cpp.s
-.PHONY : tests/const_test_suite/const_redeclaration_test.s
-
-# target to generate assembly for a file
-tests/const_test_suite/const_redeclaration_test.cpp.s:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_redeclaration_test.dir/build.make CMakeFiles/const_redeclaration_test.dir/tests/const_test_suite/const_redeclaration_test.cpp.s
-.PHONY : tests/const_test_suite/const_redeclaration_test.cpp.s
-
-tests/const_test_suite/const_with_type_test.o: tests/const_test_suite/const_with_type_test.cpp.o
-.PHONY : tests/const_test_suite/const_with_type_test.o
-
-# target to build an object file
-tests/const_test_suite/const_with_type_test.cpp.o:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_with_type_test.dir/build.make CMakeFiles/const_with_type_test.dir/tests/const_test_suite/const_with_type_test.cpp.o
-.PHONY : tests/const_test_suite/const_with_type_test.cpp.o
-
-tests/const_test_suite/const_with_type_test.i: tests/const_test_suite/const_with_type_test.cpp.i
-.PHONY : tests/const_test_suite/const_with_type_test.i
-
-# target to preprocess a source file
-tests/const_test_suite/const_with_type_test.cpp.i:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_with_type_test.dir/build.make CMakeFiles/const_with_type_test.dir/tests/const_test_suite/const_with_type_test.cpp.i
-.PHONY : tests/const_test_suite/const_with_type_test.cpp.i
-
-tests/const_test_suite/const_with_type_test.s: tests/const_test_suite/const_with_type_test.cpp.s
-.PHONY : tests/const_test_suite/const_with_type_test.s
-
-# target to generate assembly for a file
-tests/const_test_suite/const_with_type_test.cpp.s:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_with_type_test.dir/build.make CMakeFiles/const_with_type_test.dir/tests/const_test_suite/const_with_type_test.cpp.s
-.PHONY : tests/const_test_suite/const_with_type_test.cpp.s
-
-tests/const_test_suite/const_without_type_test.o: tests/const_test_suite/const_without_type_test.cpp.o
-.PHONY : tests/const_test_suite/const_without_type_test.o
-
-# target to build an object file
-tests/const_test_suite/const_without_type_test.cpp.o:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_without_type_test.dir/build.make CMakeFiles/const_without_type_test.dir/tests/const_test_suite/const_without_type_test.cpp.o
-.PHONY : tests/const_test_suite/const_without_type_test.cpp.o
-
-tests/const_test_suite/const_without_type_test.i: tests/const_test_suite/const_without_type_test.cpp.i
-.PHONY : tests/const_test_suite/const_without_type_test.i
-
-# target to preprocess a source file
-tests/const_test_suite/const_without_type_test.cpp.i:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_without_type_test.dir/build.make CMakeFiles/const_without_type_test.dir/tests/const_test_suite/const_without_type_test.cpp.i
-.PHONY : tests/const_test_suite/const_without_type_test.cpp.i
-
-tests/const_test_suite/const_without_type_test.s: tests/const_test_suite/const_without_type_test.cpp.s
-.PHONY : tests/const_test_suite/const_without_type_test.s
-
-# target to generate assembly for a file
-tests/const_test_suite/const_without_type_test.cpp.s:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_without_type_test.dir/build.make CMakeFiles/const_without_type_test.dir/tests/const_test_suite/const_without_type_test.cpp.s
-.PHONY : tests/const_test_suite/const_without_type_test.cpp.s
-
-tests/const_test_suite/immutability_test.o: tests/const_test_suite/immutability_test.cpp.o
-.PHONY : tests/const_test_suite/immutability_test.o
-
-# target to build an object file
-tests/const_test_suite/immutability_test.cpp.o:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/immutability_test.dir/build.make CMakeFiles/immutability_test.dir/tests/const_test_suite/immutability_test.cpp.o
-.PHONY : tests/const_test_suite/immutability_test.cpp.o
-
-tests/const_test_suite/immutability_test.i: tests/const_test_suite/immutability_test.cpp.i
-.PHONY : tests/const_test_suite/immutability_test.i
-
-# target to preprocess a source file
-tests/const_test_suite/immutability_test.cpp.i:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/immutability_test.dir/build.make CMakeFiles/immutability_test.dir/tests/const_test_suite/immutability_test.cpp.i
-.PHONY : tests/const_test_suite/immutability_test.cpp.i
-
-tests/const_test_suite/immutability_test.s: tests/const_test_suite/immutability_test.cpp.s
-.PHONY : tests/const_test_suite/immutability_test.s
-
-# target to generate assembly for a file
-tests/const_test_suite/immutability_test.cpp.s:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/immutability_test.dir/build.make CMakeFiles/immutability_test.dir/tests/const_test_suite/immutability_test.cpp.s
-.PHONY : tests/const_test_suite/immutability_test.cpp.s
-
-tests/if_test_suite/if_else_if_else_test.o: tests/if_test_suite/if_else_if_else_test.cpp.o
-.PHONY : tests/if_test_suite/if_else_if_else_test.o
-
-# target to build an object file
-tests/if_test_suite/if_else_if_else_test.cpp.o:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/if_else_if_else_test.dir/build.make CMakeFiles/if_else_if_else_test.dir/tests/if_test_suite/if_else_if_else_test.cpp.o
-.PHONY : tests/if_test_suite/if_else_if_else_test.cpp.o
-
-tests/if_test_suite/if_else_if_else_test.i: tests/if_test_suite/if_else_if_else_test.cpp.i
-.PHONY : tests/if_test_suite/if_else_if_else_test.i
-
-# target to preprocess a source file
-tests/if_test_suite/if_else_if_else_test.cpp.i:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/if_else_if_else_test.dir/build.make CMakeFiles/if_else_if_else_test.dir/tests/if_test_suite/if_else_if_else_test.cpp.i
-.PHONY : tests/if_test_suite/if_else_if_else_test.cpp.i
-
-tests/if_test_suite/if_else_if_else_test.s: tests/if_test_suite/if_else_if_else_test.cpp.s
-.PHONY : tests/if_test_suite/if_else_if_else_test.s
-
-# target to generate assembly for a file
-tests/if_test_suite/if_else_if_else_test.cpp.s:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/if_else_if_else_test.dir/build.make CMakeFiles/if_else_if_else_test.dir/tests/if_test_suite/if_else_if_else_test.cpp.s
-.PHONY : tests/if_test_suite/if_else_if_else_test.cpp.s
-
-tests/if_test_suite/if_else_test.o: tests/if_test_suite/if_else_test.cpp.o
-.PHONY : tests/if_test_suite/if_else_test.o
-
-# target to build an object file
-tests/if_test_suite/if_else_test.cpp.o:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/if_else_test.dir/build.make CMakeFiles/if_else_test.dir/tests/if_test_suite/if_else_test.cpp.o
-.PHONY : tests/if_test_suite/if_else_test.cpp.o
-
-tests/if_test_suite/if_else_test.i: tests/if_test_suite/if_else_test.cpp.i
-.PHONY : tests/if_test_suite/if_else_test.i
-
-# target to preprocess a source file
-tests/if_test_suite/if_else_test.cpp.i:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/if_else_test.dir/build.make CMakeFiles/if_else_test.dir/tests/if_test_suite/if_else_test.cpp.i
-.PHONY : tests/if_test_suite/if_else_test.cpp.i
-
-tests/if_test_suite/if_else_test.s: tests/if_test_suite/if_else_test.cpp.s
-.PHONY : tests/if_test_suite/if_else_test.s
-
-# target to generate assembly for a file
-tests/if_test_suite/if_else_test.cpp.s:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/if_else_test.dir/build.make CMakeFiles/if_else_test.dir/tests/if_test_suite/if_else_test.cpp.s
-.PHONY : tests/if_test_suite/if_else_test.cpp.s
-
-tests/if_test_suite/if_test.o: tests/if_test_suite/if_test.cpp.o
-.PHONY : tests/if_test_suite/if_test.o
-
-# target to build an object file
-tests/if_test_suite/if_test.cpp.o:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/if_test.dir/build.make CMakeFiles/if_test.dir/tests/if_test_suite/if_test.cpp.o
-.PHONY : tests/if_test_suite/if_test.cpp.o
-
-tests/if_test_suite/if_test.i: tests/if_test_suite/if_test.cpp.i
-.PHONY : tests/if_test_suite/if_test.i
-
-# target to preprocess a source file
-tests/if_test_suite/if_test.cpp.i:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/if_test.dir/build.make CMakeFiles/if_test.dir/tests/if_test_suite/if_test.cpp.i
-.PHONY : tests/if_test_suite/if_test.cpp.i
-
-tests/if_test_suite/if_test.s: tests/if_test_suite/if_test.cpp.s
-.PHONY : tests/if_test_suite/if_test.s
-
-# target to generate assembly for a file
-tests/if_test_suite/if_test.cpp.s:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/if_test.dir/build.make CMakeFiles/if_test.dir/tests/if_test_suite/if_test.cpp.s
-.PHONY : tests/if_test_suite/if_test.cpp.s
-
-tests/lexer_test_suite/lexer_test.o: tests/lexer_test_suite/lexer_test.cpp.o
-.PHONY : tests/lexer_test_suite/lexer_test.o
-
-# target to build an object file
-tests/lexer_test_suite/lexer_test.cpp.o:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/lexer_test.dir/build.make CMakeFiles/lexer_test.dir/tests/lexer_test_suite/lexer_test.cpp.o
-.PHONY : tests/lexer_test_suite/lexer_test.cpp.o
-
-tests/lexer_test_suite/lexer_test.i: tests/lexer_test_suite/lexer_test.cpp.i
-.PHONY : tests/lexer_test_suite/lexer_test.i
-
-# target to preprocess a source file
-tests/lexer_test_suite/lexer_test.cpp.i:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/lexer_test.dir/build.make CMakeFiles/lexer_test.dir/tests/lexer_test_suite/lexer_test.cpp.i
-.PHONY : tests/lexer_test_suite/lexer_test.cpp.i
-
-tests/lexer_test_suite/lexer_test.s: tests/lexer_test_suite/lexer_test.cpp.s
-.PHONY : tests/lexer_test_suite/lexer_test.s
-
-# target to generate assembly for a file
-tests/lexer_test_suite/lexer_test.cpp.s:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/lexer_test.dir/build.make CMakeFiles/lexer_test.dir/tests/lexer_test_suite/lexer_test.cpp.s
-.PHONY : tests/lexer_test_suite/lexer_test.cpp.s
-
-tests/parser_test_suite/parser_test.o: tests/parser_test_suite/parser_test.cpp.o
-.PHONY : tests/parser_test_suite/parser_test.o
-
-# target to build an object file
-tests/parser_test_suite/parser_test.cpp.o:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/parser_test.dir/build.make CMakeFiles/parser_test.dir/tests/parser_test_suite/parser_test.cpp.o
-.PHONY : tests/parser_test_suite/parser_test.cpp.o
-
-tests/parser_test_suite/parser_test.i: tests/parser_test_suite/parser_test.cpp.i
-.PHONY : tests/parser_test_suite/parser_test.i
-
-# target to preprocess a source file
-tests/parser_test_suite/parser_test.cpp.i:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/parser_test.dir/build.make CMakeFiles/parser_test.dir/tests/parser_test_suite/parser_test.cpp.i
-.PHONY : tests/parser_test_suite/parser_test.cpp.i
-
-tests/parser_test_suite/parser_test.s: tests/parser_test_suite/parser_test.cpp.s
-.PHONY : tests/parser_test_suite/parser_test.s
-
-# target to generate assembly for a file
-tests/parser_test_suite/parser_test.cpp.s:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/parser_test.dir/build.make CMakeFiles/parser_test.dir/tests/parser_test_suite/parser_test.cpp.s
-.PHONY : tests/parser_test_suite/parser_test.cpp.s
-
-tests/symbol_table_test_suite/const_redeclaration_scope_test.o: tests/symbol_table_test_suite/const_redeclaration_scope_test.cpp.o
-.PHONY : tests/symbol_table_test_suite/const_redeclaration_scope_test.o
-
-# target to build an object file
-tests/symbol_table_test_suite/const_redeclaration_scope_test.cpp.o:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_redeclaration_scope_test.dir/build.make CMakeFiles/const_redeclaration_scope_test.dir/tests/symbol_table_test_suite/const_redeclaration_scope_test.cpp.o
-.PHONY : tests/symbol_table_test_suite/const_redeclaration_scope_test.cpp.o
-
-tests/symbol_table_test_suite/const_redeclaration_scope_test.i: tests/symbol_table_test_suite/const_redeclaration_scope_test.cpp.i
-.PHONY : tests/symbol_table_test_suite/const_redeclaration_scope_test.i
-
-# target to preprocess a source file
-tests/symbol_table_test_suite/const_redeclaration_scope_test.cpp.i:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_redeclaration_scope_test.dir/build.make CMakeFiles/const_redeclaration_scope_test.dir/tests/symbol_table_test_suite/const_redeclaration_scope_test.cpp.i
-.PHONY : tests/symbol_table_test_suite/const_redeclaration_scope_test.cpp.i
-
-tests/symbol_table_test_suite/const_redeclaration_scope_test.s: tests/symbol_table_test_suite/const_redeclaration_scope_test.cpp.s
-.PHONY : tests/symbol_table_test_suite/const_redeclaration_scope_test.s
-
-# target to generate assembly for a file
-tests/symbol_table_test_suite/const_redeclaration_scope_test.cpp.s:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_redeclaration_scope_test.dir/build.make CMakeFiles/const_redeclaration_scope_test.dir/tests/symbol_table_test_suite/const_redeclaration_scope_test.cpp.s
-.PHONY : tests/symbol_table_test_suite/const_redeclaration_scope_test.cpp.s
-
-tests/symbol_table_test_suite/const_scope_test.o: tests/symbol_table_test_suite/const_scope_test.cpp.o
-.PHONY : tests/symbol_table_test_suite/const_scope_test.o
-
-# target to build an object file
-tests/symbol_table_test_suite/const_scope_test.cpp.o:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_scope_test.dir/build.make CMakeFiles/const_scope_test.dir/tests/symbol_table_test_suite/const_scope_test.cpp.o
-.PHONY : tests/symbol_table_test_suite/const_scope_test.cpp.o
-
-tests/symbol_table_test_suite/const_scope_test.i: tests/symbol_table_test_suite/const_scope_test.cpp.i
-.PHONY : tests/symbol_table_test_suite/const_scope_test.i
-
-# target to preprocess a source file
-tests/symbol_table_test_suite/const_scope_test.cpp.i:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_scope_test.dir/build.make CMakeFiles/const_scope_test.dir/tests/symbol_table_test_suite/const_scope_test.cpp.i
-.PHONY : tests/symbol_table_test_suite/const_scope_test.cpp.i
-
-tests/symbol_table_test_suite/const_scope_test.s: tests/symbol_table_test_suite/const_scope_test.cpp.s
-.PHONY : tests/symbol_table_test_suite/const_scope_test.s
-
-# target to generate assembly for a file
-tests/symbol_table_test_suite/const_scope_test.cpp.s:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/const_scope_test.dir/build.make CMakeFiles/const_scope_test.dir/tests/symbol_table_test_suite/const_scope_test.cpp.s
-.PHONY : tests/symbol_table_test_suite/const_scope_test.cpp.s
-
-tests/symbol_table_test_suite/var_redeclaration_scope_test.o: tests/symbol_table_test_suite/var_redeclaration_scope_test.cpp.o
-.PHONY : tests/symbol_table_test_suite/var_redeclaration_scope_test.o
-
-# target to build an object file
-tests/symbol_table_test_suite/var_redeclaration_scope_test.cpp.o:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/var_redeclaration_scope_test.dir/build.make CMakeFiles/var_redeclaration_scope_test.dir/tests/symbol_table_test_suite/var_redeclaration_scope_test.cpp.o
-.PHONY : tests/symbol_table_test_suite/var_redeclaration_scope_test.cpp.o
-
-tests/symbol_table_test_suite/var_redeclaration_scope_test.i: tests/symbol_table_test_suite/var_redeclaration_scope_test.cpp.i
-.PHONY : tests/symbol_table_test_suite/var_redeclaration_scope_test.i
-
-# target to preprocess a source file
-tests/symbol_table_test_suite/var_redeclaration_scope_test.cpp.i:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/var_redeclaration_scope_test.dir/build.make CMakeFiles/var_redeclaration_scope_test.dir/tests/symbol_table_test_suite/var_redeclaration_scope_test.cpp.i
-.PHONY : tests/symbol_table_test_suite/var_redeclaration_scope_test.cpp.i
-
-tests/symbol_table_test_suite/var_redeclaration_scope_test.s: tests/symbol_table_test_suite/var_redeclaration_scope_test.cpp.s
-.PHONY : tests/symbol_table_test_suite/var_redeclaration_scope_test.s
-
-# target to generate assembly for a file
-tests/symbol_table_test_suite/var_redeclaration_scope_test.cpp.s:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/var_redeclaration_scope_test.dir/build.make CMakeFiles/var_redeclaration_scope_test.dir/tests/symbol_table_test_suite/var_redeclaration_scope_test.cpp.s
-.PHONY : tests/symbol_table_test_suite/var_redeclaration_scope_test.cpp.s
-
-tests/symbol_table_test_suite/vars_scope_test.o: tests/symbol_table_test_suite/vars_scope_test.cpp.o
-.PHONY : tests/symbol_table_test_suite/vars_scope_test.o
-
-# target to build an object file
-tests/symbol_table_test_suite/vars_scope_test.cpp.o:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/vars_scope_test.dir/build.make CMakeFiles/vars_scope_test.dir/tests/symbol_table_test_suite/vars_scope_test.cpp.o
-.PHONY : tests/symbol_table_test_suite/vars_scope_test.cpp.o
-
-tests/symbol_table_test_suite/vars_scope_test.i: tests/symbol_table_test_suite/vars_scope_test.cpp.i
-.PHONY : tests/symbol_table_test_suite/vars_scope_test.i
-
-# target to preprocess a source file
-tests/symbol_table_test_suite/vars_scope_test.cpp.i:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/vars_scope_test.dir/build.make CMakeFiles/vars_scope_test.dir/tests/symbol_table_test_suite/vars_scope_test.cpp.i
-.PHONY : tests/symbol_table_test_suite/vars_scope_test.cpp.i
-
-tests/symbol_table_test_suite/vars_scope_test.s: tests/symbol_table_test_suite/vars_scope_test.cpp.s
-.PHONY : tests/symbol_table_test_suite/vars_scope_test.s
-
-# target to generate assembly for a file
-tests/symbol_table_test_suite/vars_scope_test.cpp.s:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/vars_scope_test.dir/build.make CMakeFiles/vars_scope_test.dir/tests/symbol_table_test_suite/vars_scope_test.cpp.s
-.PHONY : tests/symbol_table_test_suite/vars_scope_test.cpp.s
-
-tests/ternary_test_suite/assignment_with_ternary_test.o: tests/ternary_test_suite/assignment_with_ternary_test.cpp.o
-.PHONY : tests/ternary_test_suite/assignment_with_ternary_test.o
-
-# target to build an object file
-tests/ternary_test_suite/assignment_with_ternary_test.cpp.o:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/assignment_with_ternary_test.dir/build.make CMakeFiles/assignment_with_ternary_test.dir/tests/ternary_test_suite/assignment_with_ternary_test.cpp.o
-.PHONY : tests/ternary_test_suite/assignment_with_ternary_test.cpp.o
-
-tests/ternary_test_suite/assignment_with_ternary_test.i: tests/ternary_test_suite/assignment_with_ternary_test.cpp.i
-.PHONY : tests/ternary_test_suite/assignment_with_ternary_test.i
-
-# target to preprocess a source file
-tests/ternary_test_suite/assignment_with_ternary_test.cpp.i:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/assignment_with_ternary_test.dir/build.make CMakeFiles/assignment_with_ternary_test.dir/tests/ternary_test_suite/assignment_with_ternary_test.cpp.i
-.PHONY : tests/ternary_test_suite/assignment_with_ternary_test.cpp.i
-
-tests/ternary_test_suite/assignment_with_ternary_test.s: tests/ternary_test_suite/assignment_with_ternary_test.cpp.s
-.PHONY : tests/ternary_test_suite/assignment_with_ternary_test.s
-
-# target to generate assembly for a file
-tests/ternary_test_suite/assignment_with_ternary_test.cpp.s:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/assignment_with_ternary_test.dir/build.make CMakeFiles/assignment_with_ternary_test.dir/tests/ternary_test_suite/assignment_with_ternary_test.cpp.s
-.PHONY : tests/ternary_test_suite/assignment_with_ternary_test.cpp.s
-
-tests/ternary_test_suite/nested_ternary_test.o: tests/ternary_test_suite/nested_ternary_test.cpp.o
-.PHONY : tests/ternary_test_suite/nested_ternary_test.o
-
-# target to build an object file
-tests/ternary_test_suite/nested_ternary_test.cpp.o:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/nested_ternary_test.dir/build.make CMakeFiles/nested_ternary_test.dir/tests/ternary_test_suite/nested_ternary_test.cpp.o
-.PHONY : tests/ternary_test_suite/nested_ternary_test.cpp.o
-
-tests/ternary_test_suite/nested_ternary_test.i: tests/ternary_test_suite/nested_ternary_test.cpp.i
-.PHONY : tests/ternary_test_suite/nested_ternary_test.i
-
-# target to preprocess a source file
-tests/ternary_test_suite/nested_ternary_test.cpp.i:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/nested_ternary_test.dir/build.make CMakeFiles/nested_ternary_test.dir/tests/ternary_test_suite/nested_ternary_test.cpp.i
-.PHONY : tests/ternary_test_suite/nested_ternary_test.cpp.i
-
-tests/ternary_test_suite/nested_ternary_test.s: tests/ternary_test_suite/nested_ternary_test.cpp.s
-.PHONY : tests/ternary_test_suite/nested_ternary_test.s
-
-# target to generate assembly for a file
-tests/ternary_test_suite/nested_ternary_test.cpp.s:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/nested_ternary_test.dir/build.make CMakeFiles/nested_ternary_test.dir/tests/ternary_test_suite/nested_ternary_test.cpp.s
-.PHONY : tests/ternary_test_suite/nested_ternary_test.cpp.s
-
-tests/ternary_test_suite/ternary_test.o: tests/ternary_test_suite/ternary_test.cpp.o
-.PHONY : tests/ternary_test_suite/ternary_test.o
-
-# target to build an object file
-tests/ternary_test_suite/ternary_test.cpp.o:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/ternary_test.dir/build.make CMakeFiles/ternary_test.dir/tests/ternary_test_suite/ternary_test.cpp.o
-.PHONY : tests/ternary_test_suite/ternary_test.cpp.o
-
-tests/ternary_test_suite/ternary_test.i: tests/ternary_test_suite/ternary_test.cpp.i
-.PHONY : tests/ternary_test_suite/ternary_test.i
-
-# target to preprocess a source file
-tests/ternary_test_suite/ternary_test.cpp.i:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/ternary_test.dir/build.make CMakeFiles/ternary_test.dir/tests/ternary_test_suite/ternary_test.cpp.i
-.PHONY : tests/ternary_test_suite/ternary_test.cpp.i
-
-tests/ternary_test_suite/ternary_test.s: tests/ternary_test_suite/ternary_test.cpp.s
-.PHONY : tests/ternary_test_suite/ternary_test.s
-
-# target to generate assembly for a file
-tests/ternary_test_suite/ternary_test.cpp.s:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/ternary_test.dir/build.make CMakeFiles/ternary_test.dir/tests/ternary_test_suite/ternary_test.cpp.s
-.PHONY : tests/ternary_test_suite/ternary_test.cpp.s
-
-tests/vars_test_suite/mutability_test.o: tests/vars_test_suite/mutability_test.cpp.o
-.PHONY : tests/vars_test_suite/mutability_test.o
-
-# target to build an object file
-tests/vars_test_suite/mutability_test.cpp.o:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/mutability_test.dir/build.make CMakeFiles/mutability_test.dir/tests/vars_test_suite/mutability_test.cpp.o
-.PHONY : tests/vars_test_suite/mutability_test.cpp.o
-
-tests/vars_test_suite/mutability_test.i: tests/vars_test_suite/mutability_test.cpp.i
-.PHONY : tests/vars_test_suite/mutability_test.i
-
-# target to preprocess a source file
-tests/vars_test_suite/mutability_test.cpp.i:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/mutability_test.dir/build.make CMakeFiles/mutability_test.dir/tests/vars_test_suite/mutability_test.cpp.i
-.PHONY : tests/vars_test_suite/mutability_test.cpp.i
-
-tests/vars_test_suite/mutability_test.s: tests/vars_test_suite/mutability_test.cpp.s
-.PHONY : tests/vars_test_suite/mutability_test.s
-
-# target to generate assembly for a file
-tests/vars_test_suite/mutability_test.cpp.s:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/mutability_test.dir/build.make CMakeFiles/mutability_test.dir/tests/vars_test_suite/mutability_test.cpp.s
-.PHONY : tests/vars_test_suite/mutability_test.cpp.s
-
-tests/vars_test_suite/var_redeclaration_test.o: tests/vars_test_suite/var_redeclaration_test.cpp.o
-.PHONY : tests/vars_test_suite/var_redeclaration_test.o
-
-# target to build an object file
-tests/vars_test_suite/var_redeclaration_test.cpp.o:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/var_redeclaration_test.dir/build.make CMakeFiles/var_redeclaration_test.dir/tests/vars_test_suite/var_redeclaration_test.cpp.o
-.PHONY : tests/vars_test_suite/var_redeclaration_test.cpp.o
-
-tests/vars_test_suite/var_redeclaration_test.i: tests/vars_test_suite/var_redeclaration_test.cpp.i
-.PHONY : tests/vars_test_suite/var_redeclaration_test.i
-
-# target to preprocess a source file
-tests/vars_test_suite/var_redeclaration_test.cpp.i:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/var_redeclaration_test.dir/build.make CMakeFiles/var_redeclaration_test.dir/tests/vars_test_suite/var_redeclaration_test.cpp.i
-.PHONY : tests/vars_test_suite/var_redeclaration_test.cpp.i
-
-tests/vars_test_suite/var_redeclaration_test.s: tests/vars_test_suite/var_redeclaration_test.cpp.s
-.PHONY : tests/vars_test_suite/var_redeclaration_test.s
-
-# target to generate assembly for a file
-tests/vars_test_suite/var_redeclaration_test.cpp.s:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/var_redeclaration_test.dir/build.make CMakeFiles/var_redeclaration_test.dir/tests/vars_test_suite/var_redeclaration_test.cpp.s
-.PHONY : tests/vars_test_suite/var_redeclaration_test.cpp.s
-
-tests/vars_test_suite/vars_with_type_test.o: tests/vars_test_suite/vars_with_type_test.cpp.o
-.PHONY : tests/vars_test_suite/vars_with_type_test.o
-
-# target to build an object file
-tests/vars_test_suite/vars_with_type_test.cpp.o:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/vars_with_type_test.dir/build.make CMakeFiles/vars_with_type_test.dir/tests/vars_test_suite/vars_with_type_test.cpp.o
-.PHONY : tests/vars_test_suite/vars_with_type_test.cpp.o
-
-tests/vars_test_suite/vars_with_type_test.i: tests/vars_test_suite/vars_with_type_test.cpp.i
-.PHONY : tests/vars_test_suite/vars_with_type_test.i
-
-# target to preprocess a source file
-tests/vars_test_suite/vars_with_type_test.cpp.i:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/vars_with_type_test.dir/build.make CMakeFiles/vars_with_type_test.dir/tests/vars_test_suite/vars_with_type_test.cpp.i
-.PHONY : tests/vars_test_suite/vars_with_type_test.cpp.i
-
-tests/vars_test_suite/vars_with_type_test.s: tests/vars_test_suite/vars_with_type_test.cpp.s
-.PHONY : tests/vars_test_suite/vars_with_type_test.s
-
-# target to generate assembly for a file
-tests/vars_test_suite/vars_with_type_test.cpp.s:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/vars_with_type_test.dir/build.make CMakeFiles/vars_with_type_test.dir/tests/vars_test_suite/vars_with_type_test.cpp.s
-.PHONY : tests/vars_test_suite/vars_with_type_test.cpp.s
-
-tests/vars_test_suite/vars_without_type_test.o: tests/vars_test_suite/vars_without_type_test.cpp.o
-.PHONY : tests/vars_test_suite/vars_without_type_test.o
-
-# target to build an object file
-tests/vars_test_suite/vars_without_type_test.cpp.o:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/vars_without_type_test.dir/build.make CMakeFiles/vars_without_type_test.dir/tests/vars_test_suite/vars_without_type_test.cpp.o
-.PHONY : tests/vars_test_suite/vars_without_type_test.cpp.o
-
-tests/vars_test_suite/vars_without_type_test.i: tests/vars_test_suite/vars_without_type_test.cpp.i
-.PHONY : tests/vars_test_suite/vars_without_type_test.i
-
-# target to preprocess a source file
-tests/vars_test_suite/vars_without_type_test.cpp.i:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/vars_without_type_test.dir/build.make CMakeFiles/vars_without_type_test.dir/tests/vars_test_suite/vars_without_type_test.cpp.i
-.PHONY : tests/vars_test_suite/vars_without_type_test.cpp.i
-
-tests/vars_test_suite/vars_without_type_test.s: tests/vars_test_suite/vars_without_type_test.cpp.s
-.PHONY : tests/vars_test_suite/vars_without_type_test.s
-
-# target to generate assembly for a file
-tests/vars_test_suite/vars_without_type_test.cpp.s:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/vars_without_type_test.dir/build.make CMakeFiles/vars_without_type_test.dir/tests/vars_test_suite/vars_without_type_test.cpp.s
-.PHONY : tests/vars_test_suite/vars_without_type_test.cpp.s
-
-tests/while_test_suite/while_test.o: tests/while_test_suite/while_test.cpp.o
-.PHONY : tests/while_test_suite/while_test.o
-
-# target to build an object file
-tests/while_test_suite/while_test.cpp.o:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/while_test.dir/build.make CMakeFiles/while_test.dir/tests/while_test_suite/while_test.cpp.o
-.PHONY : tests/while_test_suite/while_test.cpp.o
-
-tests/while_test_suite/while_test.i: tests/while_test_suite/while_test.cpp.i
-.PHONY : tests/while_test_suite/while_test.i
-
-# target to preprocess a source file
-tests/while_test_suite/while_test.cpp.i:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/while_test.dir/build.make CMakeFiles/while_test.dir/tests/while_test_suite/while_test.cpp.i
-.PHONY : tests/while_test_suite/while_test.cpp.i
-
-tests/while_test_suite/while_test.s: tests/while_test_suite/while_test.cpp.s
-.PHONY : tests/while_test_suite/while_test.s
-
-# target to generate assembly for a file
-tests/while_test_suite/while_test.cpp.s:
-	$(MAKE) $(MAKESILENT) -f CMakeFiles/while_test.dir/build.make CMakeFiles/while_test.dir/tests/while_test_suite/while_test.cpp.s
-.PHONY : tests/while_test_suite/while_test.cpp.s
-
 # Help Target
 help:
 	@echo "The following are some of the valid targets for this Makefile:"
@@ -1072,33 +285,11 @@ help:
 	@echo "... depend"
 	@echo "... edit_cache"
 	@echo "... rebuild_cache"
-	@echo "... test"
 	@echo "... RISCVTargetParserTableGen"
 	@echo "... acc_gen"
 	@echo "... intrinsics_gen"
 	@echo "... omp_gen"
-	@echo "... assignment_with_ternary_test"
 	@echo "... compiler"
-	@echo "... const_redeclaration_scope_test"
-	@echo "... const_redeclaration_test"
-	@echo "... const_scope_test"
-	@echo "... const_with_type_test"
-	@echo "... const_without_type_test"
-	@echo "... if_else_if_else_test"
-	@echo "... if_else_test"
-	@echo "... if_test"
-	@echo "... immutability_test"
-	@echo "... lexer_test"
-	@echo "... mutability_test"
-	@echo "... nested_ternary_test"
-	@echo "... parser_test"
-	@echo "... ternary_test"
-	@echo "... var_redeclaration_scope_test"
-	@echo "... var_redeclaration_test"
-	@echo "... vars_scope_test"
-	@echo "... vars_with_type_test"
-	@echo "... vars_without_type_test"
-	@echo "... while_test"
 	@echo "... main.o"
 	@echo "... main.i"
 	@echo "... main.s"
@@ -1111,69 +302,6 @@ help:
 	@echo "... src/parser.o"
 	@echo "... src/parser.i"
 	@echo "... src/parser.s"
-	@echo "... tests/const_test_suite/const_redeclaration_test.o"
-	@echo "... tests/const_test_suite/const_redeclaration_test.i"
-	@echo "... tests/const_test_suite/const_redeclaration_test.s"
-	@echo "... tests/const_test_suite/const_with_type_test.o"
-	@echo "... tests/const_test_suite/const_with_type_test.i"
-	@echo "... tests/const_test_suite/const_with_type_test.s"
-	@echo "... tests/const_test_suite/const_without_type_test.o"
-	@echo "... tests/const_test_suite/const_without_type_test.i"
-	@echo "... tests/const_test_suite/const_without_type_test.s"
-	@echo "... tests/const_test_suite/immutability_test.o"
-	@echo "... tests/const_test_suite/immutability_test.i"
-	@echo "... tests/const_test_suite/immutability_test.s"
-	@echo "... tests/if_test_suite/if_else_if_else_test.o"
-	@echo "... tests/if_test_suite/if_else_if_else_test.i"
-	@echo "... tests/if_test_suite/if_else_if_else_test.s"
-	@echo "... tests/if_test_suite/if_else_test.o"
-	@echo "... tests/if_test_suite/if_else_test.i"
-	@echo "... tests/if_test_suite/if_else_test.s"
-	@echo "... tests/if_test_suite/if_test.o"
-	@echo "... tests/if_test_suite/if_test.i"
-	@echo "... tests/if_test_suite/if_test.s"
-	@echo "... tests/lexer_test_suite/lexer_test.o"
-	@echo "... tests/lexer_test_suite/lexer_test.i"
-	@echo "... tests/lexer_test_suite/lexer_test.s"
-	@echo "... tests/parser_test_suite/parser_test.o"
-	@echo "... tests/parser_test_suite/parser_test.i"
-	@echo "... tests/parser_test_suite/parser_test.s"
-	@echo "... tests/symbol_table_test_suite/const_redeclaration_scope_test.o"
-	@echo "... tests/symbol_table_test_suite/const_redeclaration_scope_test.i"
-	@echo "... tests/symbol_table_test_suite/const_redeclaration_scope_test.s"
-	@echo "... tests/symbol_table_test_suite/const_scope_test.o"
-	@echo "... tests/symbol_table_test_suite/const_scope_test.i"
-	@echo "... tests/symbol_table_test_suite/const_scope_test.s"
-	@echo "... tests/symbol_table_test_suite/var_redeclaration_scope_test.o"
-	@echo "... tests/symbol_table_test_suite/var_redeclaration_scope_test.i"
-	@echo "... tests/symbol_table_test_suite/var_redeclaration_scope_test.s"
-	@echo "... tests/symbol_table_test_suite/vars_scope_test.o"
-	@echo "... tests/symbol_table_test_suite/vars_scope_test.i"
-	@echo "... tests/symbol_table_test_suite/vars_scope_test.s"
-	@echo "... tests/ternary_test_suite/assignment_with_ternary_test.o"
-	@echo "... tests/ternary_test_suite/assignment_with_ternary_test.i"
-	@echo "... tests/ternary_test_suite/assignment_with_ternary_test.s"
-	@echo "... tests/ternary_test_suite/nested_ternary_test.o"
-	@echo "... tests/ternary_test_suite/nested_ternary_test.i"
-	@echo "... tests/ternary_test_suite/nested_ternary_test.s"
-	@echo "... tests/ternary_test_suite/ternary_test.o"
-	@echo "... tests/ternary_test_suite/ternary_test.i"
-	@echo "... tests/ternary_test_suite/ternary_test.s"
-	@echo "... tests/vars_test_suite/mutability_test.o"
-	@echo "... tests/vars_test_suite/mutability_test.i"
-	@echo "... tests/vars_test_suite/mutability_test.s"
-	@echo "... tests/vars_test_suite/var_redeclaration_test.o"
-	@echo "... tests/vars_test_suite/var_redeclaration_test.i"
-	@echo "... tests/vars_test_suite/var_redeclaration_test.s"
-	@echo "... tests/vars_test_suite/vars_with_type_test.o"
-	@echo "... tests/vars_test_suite/vars_with_type_test.i"
-	@echo "... tests/vars_test_suite/vars_with_type_test.s"
-	@echo "... tests/vars_test_suite/vars_without_type_test.o"
-	@echo "... tests/vars_test_suite/vars_without_type_test.i"
-	@echo "... tests/vars_test_suite/vars_without_type_test.s"
-	@echo "... tests/while_test_suite/while_test.o"
-	@echo "... tests/while_test_suite/while_test.i"
-	@echo "... tests/while_test_suite/while_test.s"
 .PHONY : help
 
 

--- a/code.bird
+++ b/code.bird
@@ -91,20 +91,15 @@ for var y = x; y <= 5; y += 1 do
 
 print x;
 
-// increments 1 more time for some reason
-
 print "while";
 while x <= 10 
     x += 1;
 
 print x;
 
-// same here...
-
 print "scoped var assignment";
 var x = 1;
 {
-    // ternary true
     x += true ? 1 : 2;
 }
 print x;

--- a/code.bird
+++ b/code.bird
@@ -120,3 +120,15 @@ var y = 0;
 
 {{{{ y += 1; }}}}
 print y;
+
+var j = 0; 
+
+while true { 
+    j += 1; 
+    print j;
+    if (j <= 2) { 
+        continue; 
+    } 
+
+    break; 
+}

--- a/code.bird
+++ b/code.bird
@@ -1,4 +1,3 @@
-/*
 while true {
     print "first";
     break;
@@ -85,15 +84,10 @@ fn concat(first: str, second: str) -> int {
 print concat("foo", "bar");
 
 print "for loop";
-for var x: int = 1; x <= 5; x += 1 do 
-    print "x = ", x;
-*/
-
-print "for";
 var x = 0;
 
-for var y = x; x <= 5; x += 1 do
-    print x;
+for var y = x; y <= 5; y += 1 do
+    x = y;
 
 print x;
 

--- a/code.bird
+++ b/code.bird
@@ -103,3 +103,20 @@ var x = 1;
     x += true ? 1 : 2;
 }
 print x;
+
+var x = 0; 
+while true { 
+    x += 1; 
+    if (x <= 2) { 
+        continue; 
+    } 
+    break; 
+}
+
+print x;
+
+
+var y = 0;
+
+{{{{ y += 1; }}}}
+print y;

--- a/code.bird
+++ b/code.bird
@@ -1,3 +1,4 @@
+/*
 while true {
     print "first";
     break;
@@ -86,3 +87,30 @@ print concat("foo", "bar");
 print "for loop";
 for var x: int = 1; x <= 5; x += 1 do 
     print "x = ", x;
+*/
+
+print "for";
+var x = 0;
+
+for var y = x; x <= 5; x += 1 do
+    print x;
+
+print x;
+
+// increments 1 more time for some reason
+
+print "while";
+while x <= 10 
+    x += 1;
+
+print x;
+
+// same here...
+
+print "scoped var assignment";
+var x = 1;
+{
+    // ternary true
+    x += true ? 1 : 2;
+}
+print x;

--- a/code.bird
+++ b/code.bird
@@ -86,49 +86,61 @@ print concat("foo", "bar");
 print "for loop";
 var z = 0;
 
-for var y = z; y <= 5; y += 1 do
+for var y = z; y <= 5; y += 1 do {
     z = y;
+    print "z = ", z;
+}
 
-print z;
+print "result: z = ", z;
 
-print "while";
-while x <= 10 
+print "while loop";
+while x <= 10 {
+    print "x = ", x;
     x += 1;
+}
 
-print x;
+print "result: x = ", x;
 
 print "scoped var assignment";
 var k = 1;
 {
     k += true ? 1 : 2;
 }
-print k;
 
-var l = 0; 
-while true { 
-    l += 1; 
-    if (l <= 2) { 
-        continue; 
-    } 
-    break; 
-}
+print "result: k = ", k;
 
-print l;
-
-
+print "nested-nested scopes";
 var y = 0;
 
 {{{{ y += 1; }}}}
 print y;
 
+print "result: y = ", y;
+
 var j = 0; 
 
+print "while continue & break";
+print "j should equal 3";
 while true { 
     j += 1; 
-    print j;
     if (j <= 2) { 
         continue; 
     } 
 
     break; 
+}
+
+print "j = ", j;
+
+print "while test continue";
+print "shouldnt print when o = 2";
+
+var o = 0;
+
+while (o < 5) {
+    o += 1;
+    if o == 2 
+        continue;
+
+    print "o = ", o;
 }

--- a/code.bird
+++ b/code.bird
@@ -84,12 +84,12 @@ fn concat(first: str, second: str) -> int {
 print concat("foo", "bar");
 
 print "for loop";
-var x = 0;
+var z = 0;
 
-for var y = x; y <= 5; y += 1 do
-    x = y;
+for var y = z; y <= 5; y += 1 do
+    z = y;
 
-print x;
+print z;
 
 print "while";
 while x <= 10 
@@ -98,22 +98,22 @@ while x <= 10
 print x;
 
 print "scoped var assignment";
-var x = 1;
+var k = 1;
 {
-    x += true ? 1 : 2;
+    k += true ? 1 : 2;
 }
-print x;
+print k;
 
-var x = 0; 
+var l = 0; 
 while true { 
-    x += 1; 
-    if (x <= 2) { 
+    l += 1; 
+    if (l <= 2) { 
         continue; 
     } 
     break; 
 }
 
-print x;
+print l;
 
 
 var y = 0;

--- a/include/sym_table.h
+++ b/include/sym_table.h
@@ -13,7 +13,7 @@ template <typename T>
 class SymbolTable
 {
     std::map<std::string, T> vars;
-    std::unique_ptr<SymbolTable> enclosing;
+    std::shared_ptr<SymbolTable> enclosing;
 
 public:
     void insert(std::string identifier, T value)
@@ -37,14 +37,14 @@ public:
         }
     }
 
-    std::unique_ptr<SymbolTable> get_enclosing()
+    std::shared_ptr<SymbolTable> get_enclosing() const
     {
-        return std::move(this->enclosing);
+        return this->enclosing;
     }
 
-    void set_enclosing(std::unique_ptr<SymbolTable> enclosing)
+    void set_enclosing(std::shared_ptr<SymbolTable> enclosing)
     {
-        this->enclosing = std::move(enclosing);
+        this->enclosing = enclosing;
     }
 
     bool contains(std::string identifier)

--- a/include/visitors/code_gen.h
+++ b/include/visitors/code_gen.h
@@ -54,7 +54,7 @@
 class CodeGen : public Visitor
 {
     std::stack<llvm::Value *> stack;
-    std::unique_ptr<SymbolTable<llvm::Value *>> environment;
+    std::shared_ptr<SymbolTable<llvm::Value *>> environment;
     std::map<std::string, llvm::FunctionCallee> std_lib;
 
     llvm::LLVMContext context;

--- a/include/visitors/interpreter.h
+++ b/include/visitors/interpreter.h
@@ -398,6 +398,8 @@ public:
 
     void visit_while_stmt(WhileStmt *while_stmt)
     {
+        auto original_environment = this->environment;
+
         while_stmt->condition->accept(this);
         auto condition_result = std::move(this->stack.top());
         this->stack.pop();
@@ -417,6 +419,12 @@ public:
             }
             catch (ContinueException e)
             {
+                while_stmt->condition->accept(this);
+                condition_result = std::move(this->stack.top());
+                this->stack.pop();
+
+                this->environment = original_environment;
+
                 continue;
             }
 
@@ -670,6 +678,7 @@ public:
 
     void visit_break_stmt(BreakStmt *break_stmt)
     {
+        this->environment = this->environment->get_enclosing();
         throw BreakException();
     }
 

--- a/include/visitors/interpreter.h
+++ b/include/visitors/interpreter.h
@@ -405,19 +405,13 @@ public:
             // TODO: pass the UserErrorTracker into the interpreter so we can handle runtime errors
             if (type_lexeme == "int")
             {
-                if (!is_type<int>(result))
-                {
-                    is_numeric(result) ? result.data = to_type<int, float>(result)
-                                       : throw BirdException("mismatching type in assignment, expected int");
-                }
+                is_numeric(result) ? result.data = to_type<int, float>(result)
+                                   : throw BirdException("mismatching type in assignment, expected int");
             }
             else if (type_lexeme == "float")
             {
-                if (!is_type<float>(result))
-                {
-                    is_numeric(result) ? result.data = to_type<float, int>(result)
-                                       : throw BirdException("mismatching type in assignment, expected float");
-                }
+                is_numeric(result) ? result.data = to_type<float, int>(result)
+                                   : throw BirdException("mismatching type in assignment, expected float");
             }
             else if (type_lexeme == "str" && !is_type<std::string>(result))
             {

--- a/include/visitors/interpreter.h
+++ b/include/visitors/interpreter.h
@@ -174,20 +174,15 @@ public:
 
     void visit_block(Block *block)
     {
-        // std::cout << "incoming block env " << this->environment.get() << std::endl;
         std::shared_ptr<SymbolTable<Value>> new_environment = std::make_shared<SymbolTable<Value>>();
         new_environment->set_enclosing(this->environment);
-
-        // std::cout << "enclosing block env " << this->environment.get() << std::endl;
         this->environment = new_environment;
-        // std::cout << "new block env " << this->environment.get() << std::endl;
 
         for (auto &stmt : block->stmts)
         {
             stmt->accept(this);
         }
 
-        // std::cout << "revert block env " << this->environment->get_enclosing().get() << std::endl;
         this->environment = this->environment->get_enclosing();
     }
 
@@ -229,7 +224,6 @@ public:
 
     void visit_assign_expr(AssignExpr *assign_expr)
     {
-        // std::cout << "assign incomming env " << this->environment.get() << std::endl;
         bool enclosing = false;
         if (!this->environment->contains(assign_expr->identifier.lexeme))
         {

--- a/include/visitors/interpreter.h
+++ b/include/visitors/interpreter.h
@@ -113,7 +113,7 @@ public:
 
             if (auto block = dynamic_cast<Block *>(stmt.get()))
             {
-                std::cout << "initial env " << this->environment.get() << std::endl;
+                // std::cout << "initial env " << this->environment.get() << std::endl;
                 block->accept(this);
                 continue;
             }
@@ -174,20 +174,20 @@ public:
 
     void visit_block(Block *block)
     {
-        std::cout << "incoming block env " << this->environment.get() << std::endl;
+        // std::cout << "incoming block env " << this->environment.get() << std::endl;
         std::shared_ptr<SymbolTable<Value>> new_environment = std::make_shared<SymbolTable<Value>>();
         new_environment->set_enclosing(this->environment);
 
-        std::cout << "enclosing block env " << this->environment.get() << std::endl;
+        // std::cout << "enclosing block env " << this->environment.get() << std::endl;
         this->environment = new_environment;
-        std::cout << "new block env " << this->environment.get() << std::endl;
+        // std::cout << "new block env " << this->environment.get() << std::endl;
 
         for (auto &stmt : block->stmts)
         {
             stmt->accept(this);
         }
 
-        std::cout << "revert block env " << this->environment->get_enclosing().get() << std::endl;
+        // std::cout << "revert block env " << this->environment->get_enclosing().get() << std::endl;
         this->environment = this->environment->get_enclosing();
     }
 
@@ -229,7 +229,7 @@ public:
 
     void visit_assign_expr(AssignExpr *assign_expr)
     {
-        std::cout << "assign incomming env " << this->environment.get() << std::endl;
+        // std::cout << "assign incomming env " << this->environment.get() << std::endl;
         bool enclosing = false;
         if (!this->environment->contains(assign_expr->identifier.lexeme))
         {
@@ -468,7 +468,18 @@ public:
                 }
             }
 
-            for_stmt->body->accept(this);
+            try
+            {
+                for_stmt->body->accept(this);
+            }
+            catch (BreakException e)
+            {
+                break;
+            }
+            catch (ContinueException e)
+            {
+                continue;
+            }
 
             if (for_stmt->increment.has_value())
             {

--- a/include/visitors/interpreter.h
+++ b/include/visitors/interpreter.h
@@ -187,9 +187,16 @@ public:
 
     void visit_decl_stmt(DeclStmt *decl_stmt)
     {
-        if (this->environment->contains(decl_stmt->identifier.lexeme))
+        std::shared_ptr<SymbolTable<Value>> current_env = this->environment;
+
+        while (current_env)
         {
-            throw BirdException("Identifier '" + decl_stmt->identifier.lexeme + "' is already declared.");
+            if (this->environment->contains(decl_stmt->identifier.lexeme))
+            {
+                throw BirdException("Identifier '" + decl_stmt->identifier.lexeme + "' is already declared.");
+            }
+
+            current_env = current_env->get_enclosing();
         }
 
         decl_stmt->value->accept(this);
@@ -374,9 +381,16 @@ public:
 
     void visit_const_stmt(ConstStmt *const_stmt)
     {
-        if (this->environment->contains(const_stmt->identifier.lexeme))
+        std::shared_ptr<SymbolTable<Value>> current_env = this->environment;
+
+        while (current_env)
         {
-            throw BirdException("Identifier '" + const_stmt->identifier.lexeme + "' is already declared.");
+            if (this->environment->contains(const_stmt->identifier.lexeme))
+            {
+                throw BirdException("Identifier '" + const_stmt->identifier.lexeme + "' is already declared.");
+            }
+
+            current_env = current_env->get_enclosing();
         }
 
         const_stmt->value->accept(this);

--- a/include/visitors/interpreter.h
+++ b/include/visitors/interpreter.h
@@ -284,8 +284,8 @@ public:
             else
                 THROW_UNKNWOWN_COMPASSIGN_OPERATOR(+);
 
-            enclosing ? this->environment->get_enclosing()->insert(assign_expr->identifier.lexeme, value)
-                      : this->environment->insert(assign_expr->identifier.lexeme, value);
+            enclosing ? this->environment->get_enclosing()->insert(assign_expr->identifier.lexeme, previous_value)
+                      : this->environment->insert(assign_expr->identifier.lexeme, previous_value);
             break;
         }
         case Token::Type::MINUS_EQUAL:
@@ -299,8 +299,8 @@ public:
             else
                 THROW_UNKNWOWN_COMPASSIGN_OPERATOR(-);
 
-            enclosing ? this->environment->get_enclosing()->insert(assign_expr->identifier.lexeme, value)
-                      : this->environment->insert(assign_expr->identifier.lexeme, value);
+            enclosing ? this->environment->get_enclosing()->insert(assign_expr->identifier.lexeme, previous_value)
+                      : this->environment->insert(assign_expr->identifier.lexeme, previous_value);
             break;
         }
         case Token::Type::STAR_EQUAL:
@@ -314,8 +314,8 @@ public:
             else
                 THROW_UNKNWOWN_COMPASSIGN_OPERATOR(*);
 
-            enclosing ? this->environment->get_enclosing()->insert(assign_expr->identifier.lexeme, value)
-                      : this->environment->insert(assign_expr->identifier.lexeme, value);
+            enclosing ? this->environment->get_enclosing()->insert(assign_expr->identifier.lexeme, previous_value)
+                      : this->environment->insert(assign_expr->identifier.lexeme, previous_value);
             break;
         }
         case Token::Type::SLASH_EQUAL:
@@ -329,8 +329,8 @@ public:
             else
                 THROW_UNKNWOWN_COMPASSIGN_OPERATOR(/);
 
-            enclosing ? this->environment->get_enclosing()->insert(assign_expr->identifier.lexeme, value)
-                      : this->environment->insert(assign_expr->identifier.lexeme, value);
+            enclosing ? this->environment->get_enclosing()->insert(assign_expr->identifier.lexeme, previous_value)
+                      : this->environment->insert(assign_expr->identifier.lexeme, previous_value);
             break;
         }
         case Token::Type::PERCENT_EQUAL:
@@ -341,8 +341,8 @@ public:
             else
                 THROW_UNKNWOWN_COMPASSIGN_OPERATOR(%);
 
-            enclosing ? this->environment->get_enclosing()->insert(assign_expr->identifier.lexeme, value)
-                      : this->environment->insert(assign_expr->identifier.lexeme, value);
+            enclosing ? this->environment->get_enclosing()->insert(assign_expr->identifier.lexeme, previous_value)
+                      : this->environment->insert(assign_expr->identifier.lexeme, previous_value);
             break;
         }
         default:

--- a/tests/while_test_suite/while_test.cpp
+++ b/tests/while_test_suite/while_test.cpp
@@ -14,7 +14,7 @@ TEST(WhileTest, While)
 
     ASSERT_TRUE(interpreter.environment->contains("x"));
     ASSERT_TRUE(is_type<int>(interpreter.environment->get("x")));
-    ASSERT_EQ(as_type<int>(interpreter.environment->get("x")), 9);
+    ASSERT_EQ(as_type<int>(interpreter.environment->get("x")), 10);
 }
 
 TEST(WhileTest, WhileFalse)


### PR DESCRIPTION
### std::unique_ptr
```
var x = 0
{ x = 1; }
print x

initial env 0xaaaad6d452f0
incoming block env 0xaaaad6d452f0
enclosing block env 0 # enclosing block never set
new block env 0xaaaad6d453f0
assign incoming env 0xaaaad6d453f0
Identifier 'x' is not initialized.
```
### std::shared_ptr
```
var x = 0
{ x = 1; }
print x

initial env 0xaaaafcf51bf0
incoming block env 0xaaaafcf51bf0
enclosing block env 0xaaaafcf51bf0 # gets set!
new block env 0xaaaafcf51d30
assign incoming env 0xaaaafcf51d30
revert block env 0xaaaafcf51bf0
0
```

### modification to visit_assign_expr()
```
var x = 0
{ x = 1; }
print x
initial env 0xaaaaf2277bf0
incoming block env 0xaaaaf2277bf0
enclosing block env 0xaaaaf2277bf0
new block env 0xaaaaf2277d30
assign incoming env 0xaaaaf2277d30
revert block env 0xaaaaf2277bf0
1
```